### PR TITLE
Fix estimation logic and remove stale estimates

### DIFF
--- a/core/services/finance_estimation.py
+++ b/core/services/finance_estimation.py
@@ -1,208 +1,12 @@
 import logging
-from decimal import Decimal
-from django.db import connection
-from django.db.models import Sum, Q
-from ..models import DatePeriod, AccountBalance, Transaction, Account
-
-logger = logging.getLogger(__name__)
-
-class FinanceEstimationService:
-    """Service for financial transaction estimation."""
-
-    def __init__(self, user):
-        self.user = user
-
-    def estimate_transaction_for_period(self, period):
-        """Estimate missing transaction for a specific period."""
-        try:
-            summary = self.get_estimation_summary(period)
-
-            if summary['status'] == 'balanced':
-                logger.info(f"Period {period.label} is already balanced")
-                return None
-
-            # Calculate missing amount
-            missing_amount = summary['estimated_amount']
-            if abs(missing_amount) < 0.01:  # Ignore very small amounts
-                return None
-
-            # Determine transaction type
-            if summary['status'] == 'missing_expenses':
-                tx_type = 'EX'
-                amount = abs(missing_amount)
-            elif summary['status'] == 'missing_income':
-                tx_type = 'IN'
-                amount = abs(missing_amount)
-            else:
-                return None
-
-            # Get or create default account
-            default_account = Account.objects.filter(
-                user=self.user, 
-                name__icontains='checking'
-            ).first()
-
-            if not default_account:
-                default_account = Account.objects.filter(user=self.user).first()
-
-            if not default_account:
-                logger.error(f"No accounts found for user {self.user.id}")
-                return None
-
-            # Create estimated transaction
-            estimated_tx = Transaction.objects.create(
-                user=self.user,
-                type=tx_type,
-                amount=amount,
-                date=period.get_last_day(),
-                notes=f"Estimated {tx_type} transaction for {period.label}",
-                is_estimated=True,
-                period=period,
-                account=default_account
-            )
-
-            logger.info(f"Created estimated transaction {estimated_tx.id} for period {period.label}")
-            return estimated_tx
-
-        except Exception as e:
-            logger.error(f"Error estimating transaction for period {period.label}: {e}")
-            return None
-
-    def get_estimation_summary(self, period):
-        """Get estimation summary for a period."""
-        try:
-            # Get next period
-            next_period = self._get_next_period(period)
-
-            # Get recorded transactions
-            transactions = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=False
-            ).aggregate(
-                income=Sum('amount', filter=Q(type='IN')) or Decimal('0'),
-                expenses=Sum('amount', filter=Q(type='EX')) or Decimal('0'),
-                investments=Sum('amount', filter=Q(type='IV')) or Decimal('0')
-            )
-
-            income_inserted = transactions['income'] or Decimal('0')
-            expense_inserted = abs(transactions['expenses'] or Decimal('0'))
-            investment_inserted = transactions['investments'] or Decimal('0')
-
-            # Get account balances
-            current_savings = self._get_savings_balance(period)
-            next_savings = self._get_savings_balance(next_period) if next_period else current_savings
-
-            # Calculate estimated expenses
-            savings_diff = next_savings - current_savings
-            estimated_expenses = income_inserted + savings_diff - investment_inserted
-
-            # Calculate missing amounts
-            missing_expenses = max(0, estimated_expenses - expense_inserted)
-            missing_income = max(0, expense_inserted - estimated_expenses)
-
-            # Determine status
-            if abs(missing_expenses) < 1 and abs(missing_income) < 1:
-                status = 'balanced'
-                status_message = 'All transactions reconciled'
-                estimated_amount = 0
-                estimated_type = None
-            elif missing_expenses > 1:
-                status = 'missing_expenses'
-                status_message = f'Missing €{missing_expenses:.2f} in expenses'
-                estimated_amount = missing_expenses
-                estimated_type = 'EX'
-            else:
-                status = 'missing_income'
-                status_message = f'Missing €{missing_income:.2f} in income'
-                estimated_amount = missing_income
-                estimated_type = 'IN'
-
-            # Check if estimated transaction exists
-            estimated_tx = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=True
-            ).first()
-
-            return {
-                'period_id': period.id,
-                'period': period.label,
-                'status': status,
-                'status_message': status_message,
-                'estimated_amount': float(estimated_amount),
-                'estimated_type': estimated_type,
-                'has_estimated_transaction': estimated_tx is not None,
-                'estimated_transaction_id': estimated_tx.id if estimated_tx else None,
-                'details': {
-                    'income_inserted': float(income_inserted),
-                    'expense_inserted': float(expense_inserted),
-                    'investment_inserted': float(investment_inserted),
-                    'savings_current': float(current_savings),
-                    'savings_next': float(next_savings),
-                    'estimated_expenses': float(estimated_expenses),
-                    'missing_expenses': float(missing_expenses),
-                    'missing_income': float(missing_income)
-                }
-            }
-
-        except Exception as e:
-            logger.error(f"Error getting estimation summary for period {period.label}: {e}")
-            return {
-                'period_id': period.id,
-                'period': period.label,
-                'status': 'error',
-                'status_message': f'Error: {str(e)}',
-                'estimated_amount': 0,
-                'estimated_type': None,
-                'has_estimated_transaction': False,
-                'estimated_transaction_id': None,
-                'details': {}
-            }
-
-    def _get_next_period(self, period):
-        """Get the next period after the given period."""
-        try:
-            if period.month == 12:
-                next_year = period.year + 1
-                next_month = 1
-            else:
-                next_year = period.year
-                next_month = period.month + 1
-
-            return DatePeriod.objects.filter(
-                year=next_year,
-                month=next_month
-            ).first()
-
-        except Exception:
-            return None
-
-    def _get_savings_balance(self, period):
-        """Get total savings balance for a period."""
-        if not period:
-            return Decimal('0')
-
-        try:
-            balance = AccountBalance.objects.filter(
-                account__user=self.user,
-                account__account_type__name__icontains='savings',
-                period=period
-            ).aggregate(
-                total=Sum('reported_balance')
-            )['total']
-
-            return balance or Decimal('0')
-
-        except Exception as e:
-            logger.error(f"Error getting savings balance for period {period.label}: {e}")
-            return Decimal('0')
-import logging
-from decimal import Decimal
 from datetime import date
-from django.db.models import Sum, Q
+from decimal import Decimal
+
 from django.db import connection
-from ..models import Transaction, DatePeriod, AccountBalance, Account
+from django.db.models import Sum, Q
+
+from ..models import Account, AccountBalance, DatePeriod, Transaction, Category
+
 
 logger = logging.getLogger(__name__)
 
@@ -213,214 +17,207 @@ class FinanceEstimationService:
     def __init__(self, user):
         self.user = user
 
-    def get_estimation_summary(self, period):
-        """Get estimation summary for a specific period."""
-        try:
-            # Get account balances for current and next period
-            current_balances = self.get_period_balances(period)
-            next_period = self.get_next_period(period)
-            next_balances = self.get_period_balances(next_period) if next_period else {}
-
-            # Get recorded transactions for the period - separated by estimated vs real
-            real_transactions = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=False
-            ).aggregate(
-                income=Sum('amount', filter=Q(type='IN')) or Decimal('0'),
-                expenses=Sum('amount', filter=Q(type='EX')) or Decimal('0'),
-                investments=Sum('amount', filter=Q(type='IV')) or Decimal('0')
-            )
-
-            estimated_transactions = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=True
-            ).aggregate(
-                income=Sum('amount', filter=Q(type='IN')) or Decimal('0'),
-                expenses=Sum('amount', filter=Q(type='EX')) or Decimal('0'),
-                investments=Sum('amount', filter=Q(type='IV')) or Decimal('0')
-            )
-
-            # Combined totals for calculations
-            transactions = {
-                'income': (real_transactions['income'] or Decimal('0')) + (estimated_transactions['income'] or Decimal('0')),
-                'expenses': (real_transactions['expenses'] or Decimal('0')) + (estimated_transactions['expenses'] or Decimal('0')),
-                'investments': (real_transactions['investments'] or Decimal('0')) + (estimated_transactions['investments'] or Decimal('0'))
-            }
-
-            # Calculate savings difference
-            savings_current = current_balances.get('Savings', Decimal('0'))
-            savings_next = next_balances.get('Savings', Decimal('0'))
-            savings_diff = savings_next - savings_current
-
-            # Estimate missing expenses based on savings change
-            income_inserted = abs(transactions['income'] or Decimal('0'))
-            expense_inserted = abs(transactions['expenses'] or Decimal('0'))
-            investment_inserted = transactions['investments'] or Decimal('0')
-
-            # Calculate expected expenses
-            estimated_expenses = income_inserted - savings_diff - investment_inserted
-            missing_expenses = max(Decimal('0'), estimated_expenses - expense_inserted)
-            missing_income = max(Decimal('0'), -estimated_expenses) if estimated_expenses < 0 else Decimal('0')
-
-            # Check if there's an estimated transaction
-            estimated_tx = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=True
-            ).first()
-
-            # Determine status
-            status = 'balanced'
-            status_message = 'Period is balanced'
-            estimated_type = None
-            estimated_amount = Decimal('0')
-
-            if missing_expenses > 10:  # Threshold for missing expenses
-                status = 'missing_expenses'
-                status_message = f'Missing €{missing_expenses:.0f} in expenses'
-                estimated_type = 'EX'
-                estimated_amount = missing_expenses
-            elif missing_income > 10:  # Threshold for missing income
-                status = 'missing_income'
-                status_message = f'Missing €{missing_income:.0f} in income'
-                estimated_type = 'IN'
-                estimated_amount = missing_income
-
-            return {
-                'period_id': period.id,
-                'period': period.label,
-                'status': status,
-                'status_message': status_message,
-                'estimated_type': estimated_type,
-                'estimated_amount': float(estimated_amount),
-                'has_estimated_transaction': estimated_tx is not None,
-                'estimated_transaction_id': estimated_tx.id if estimated_tx else None,
-                'details': {
-                    'income_inserted': float(income_inserted),
-                    'expense_inserted': float(expense_inserted),
-                    'investment_inserted': float(investment_inserted),
-                    'savings_current': float(savings_current),
-                    'savings_next': float(savings_next),
-                    'estimated_expenses': float(estimated_expenses),
-                    'missing_expenses': float(missing_expenses),
-                    'missing_income': float(missing_income),
-                    # Real vs Estimated breakdown
-                    'real_income': float(abs(real_transactions['income'] or Decimal('0'))),
-                    'real_expenses': float(abs(real_transactions['expenses'] or Decimal('0'))),
-                    'real_investments': float(real_transactions['investments'] or Decimal('0')),
-                    'estimated_income': float(abs(estimated_transactions['income'] or Decimal('0'))),
-                    'estimated_expenses_tx': float(abs(estimated_transactions['expenses'] or Decimal('0'))),
-                    'estimated_investments': float(estimated_transactions['investments'] or Decimal('0'))
-                }
-            }
-
-        except Exception as e:
-            logger.error(f"Error getting estimation summary for period {period.id}: {e}")
-            return {
-                'period_id': period.id,
-                'period': period.label,
-                'status': 'error',
-                'status_message': f'Error: {str(e)}',
-                'estimated_type': None,
-                'estimated_amount': 0,
-                'has_estimated_transaction': False,
-                'estimated_transaction_id': None,
-                'details': {}
-            }
-
     def get_period_balances(self, period):
-        """Get account balances for a period grouped by account type."""
+        """Return account balances grouped by account type for a period."""
         if not period:
             return {}
 
         with connection.cursor() as cursor:
-            cursor.execute("""
+            cursor.execute(
+                """
                 SELECT at.name, SUM(ab.reported_balance)
                 FROM core_accountbalance ab
                 INNER JOIN core_account a ON ab.account_id = a.id
                 INNER JOIN core_accounttype at ON a.account_type_id = at.id
                 WHERE a.user_id = %s AND ab.period_id = %s
                 GROUP BY at.name
-            """, [self.user.id, period.id])
-
+                """,
+                [self.user.id, period.id],
+            )
             balances = {}
             for account_type, balance in cursor.fetchall():
                 balances[account_type] = Decimal(str(balance or 0))
-
             return balances
 
     def get_next_period(self, period):
-        """Get the next period after the given period."""
+        """Return the DatePeriod immediately after the given period."""
         try:
             if period.month == 12:
                 return DatePeriod.objects.get(year=period.year + 1, month=1)
-            else:
-                return DatePeriod.objects.get(year=period.year, month=period.month + 1)
+            return DatePeriod.objects.get(year=period.year, month=period.month + 1)
         except DatePeriod.DoesNotExist:
             return None
 
-    def delete_estimated_transaction_by_period(self, period):
-        """Delete estimated transactions for a specific period."""
+    def get_estimation_summary(self, period):
+        """Calculate estimation status for a period."""
         try:
-            # Find and delete estimated transactions for this period and user
-            estimated_transactions = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=True
+            next_period = self.get_next_period(period)
+            current_balances = self.get_period_balances(period)
+            next_balances = (
+                self.get_period_balances(next_period) if next_period else {}
             )
 
-            deleted_count = estimated_transactions.count()
-            estimated_transactions.delete()
+            real_tx = Transaction.objects.filter(
+                user=self.user, period=period, is_estimated=False
+            ).aggregate(
+                income=Sum("amount", filter=Q(type="IN")) or Decimal("0"),
+                expenses=Sum("amount", filter=Q(type="EX")) or Decimal("0"),
+                investments=Sum("amount", filter=Q(type="IV")) or Decimal("0"),
+            )
 
-            logger.info(f"Deleted {deleted_count} estimated transaction(s) for period {period.label}")
-            return deleted_count
+            income_inserted = real_tx["income"] or Decimal("0")
+            expense_inserted = abs(real_tx["expenses"] or Decimal("0"))
+            investment_inserted = real_tx["investments"] or Decimal("0")
 
+            savings_current = current_balances.get("Savings", Decimal("0"))
+            savings_next = next_balances.get("Savings", Decimal("0"))
+            savings_diff = savings_next - savings_current
+
+            estimated_expenses = income_inserted + savings_diff - investment_inserted
+            missing_expenses = max(Decimal("0"), estimated_expenses - expense_inserted)
+            missing_income = max(Decimal("0"), expense_inserted - estimated_expenses)
+
+            status = "balanced"
+            status_message = "All transactions reconciled"
+            estimated_amount = Decimal("0")
+            estimated_type = None
+
+            if missing_expenses >= Decimal("1"):
+                status = "missing_expenses"
+                status_message = f"Missing €{missing_expenses:.2f} in expenses"
+                estimated_amount = missing_expenses
+                estimated_type = "EX"
+            elif missing_income >= Decimal("1"):
+                status = "missing_income"
+                status_message = f"Missing €{missing_income:.2f} in income"
+                estimated_amount = missing_income
+                estimated_type = "IN"
+
+            estimated_tx = Transaction.objects.filter(
+                user=self.user, period=period, is_estimated=True
+            ).first()
+
+            # If a manual transaction exists for the missing type, treat as balanced
+            if estimated_type and Transaction.objects.filter(
+                user=self.user,
+                period=period,
+                type=estimated_type,
+                is_estimated=False,
+            ).exists():
+                self.delete_estimated_transaction_by_period(period, estimated_type)
+                status = "balanced"
+                status_message = "All transactions reconciled"
+                estimated_amount = Decimal("0")
+                estimated_type = None
+                estimated_tx = None
+
+            return {
+                "period_id": period.id,
+                "period": period.label,
+                "status": status,
+                "status_message": status_message,
+                "estimated_amount": float(estimated_amount),
+                "estimated_type": estimated_type,
+                "has_estimated_transaction": estimated_tx is not None,
+                "estimated_transaction_id": estimated_tx.id if estimated_tx else None,
+                "details": {
+                    "income_inserted": float(income_inserted),
+                    "expense_inserted": float(expense_inserted),
+                    "investment_inserted": float(investment_inserted),
+                    "savings_current": float(savings_current),
+                    "savings_next": float(savings_next),
+                    "estimated_expenses": float(estimated_expenses),
+                    "missing_expenses": float(missing_expenses),
+                    "missing_income": float(missing_income),
+                },
+            }
         except Exception as e:
-            logger.error(f"Error deleting estimated transactions for period {period.id}: {e}")
-            raise
+            logger.error(
+                "Error getting estimation summary for period %s: %s", period.id, e
+            )
+            return {
+                "period_id": period.id,
+                "period": period.label,
+                "status": "error",
+                "status_message": f"Error: {e}",
+                "estimated_amount": 0,
+                "estimated_type": None,
+                "has_estimated_transaction": False,
+                "estimated_transaction_id": None,
+                "details": {},
+            }
+
+    def delete_estimated_transaction_by_period(self, period, tx_type=None):
+        """Delete estimated transactions for a given period (optionally filtered by type)."""
+        qs = Transaction.objects.filter(
+            user=self.user, period=period, is_estimated=True
+        )
+        if tx_type:
+            qs = qs.filter(type=tx_type)
+        deleted, _ = qs.delete()
+        if deleted:
+            logger.info(
+                "Deleted %s estimated transaction(s) for period %s", deleted, period.label
+            )
+        return deleted
 
     def estimate_transaction_for_period(self, period):
-        """Create or update estimated transaction for a period."""
+        """Create an estimated transaction if a period is missing data."""
         try:
             summary = self.get_estimation_summary(period)
 
-            if summary['status'] == 'error' or summary['estimated_amount'] <= 10:
+            tx_type = summary.get("estimated_type")
+            amount = Decimal(str(summary.get("estimated_amount", 0)))
+
+            # Nothing missing -> ensure estimates removed and exit
+            if summary["status"] == "balanced" or not tx_type or amount < Decimal("0.01"):
+                if tx_type:
+                    self.delete_estimated_transaction_by_period(period, tx_type)
+                else:
+                    self.delete_estimated_transaction_by_period(period)
                 return None
 
-            # Delete existing estimated transaction using the service method
-            self.delete_estimated_transaction_by_period(period)
+            # Skip if a manual transaction already exists
+            if Transaction.objects.filter(
+                user=self.user,
+                period=period,
+                type=tx_type,
+                is_estimated=False,
+            ).exists():
+                self.delete_estimated_transaction_by_period(period, tx_type)
+                return None
 
-            # Create new estimated transaction
-            from ..models import Category
+            # Remove previous estimates for this period/type
+            self.delete_estimated_transaction_by_period(period, tx_type)
 
-            # Get or create estimation category
             category, _ = Category.objects.get_or_create(
-                name='Estimated Transaction',
-                user=self.user
+                name="Estimated Transaction", user=self.user
             )
 
-            # Get default account
-            account = Account.objects.filter(user=self.user).first()
-            if not account:
-                raise Exception("No account found for user")
+            default_account = Account.objects.filter(
+                user=self.user, name__icontains="checking"
+            ).first() or Account.objects.filter(user=self.user).first()
+            if not default_account:
+                logger.error("No accounts found for user %s", self.user.id)
+                return None
 
             estimated_tx = Transaction.objects.create(
                 user=self.user,
-                type=summary['estimated_type'],
-                amount=Decimal(str(summary['estimated_amount'])),
-                date=date(period.year, period.month, 15),  # Mid-month
-                notes=f"Estimated {summary['estimated_type']} for {period.label}",
+                type=tx_type,
+                amount=amount,
+                date=period.get_last_day(),
+                notes=f"Estimated {tx_type} transaction for {period.label}",
                 is_estimated=True,
                 period=period,
-                account=account,
-                category=category
+                account=default_account,
+                category=category,
             )
-
-            logger.info(f"Created estimated transaction {estimated_tx.id} for period {period.label}")
+            logger.info(
+                "Created estimated transaction %s for period %s", estimated_tx.id, period.label
+            )
             return estimated_tx
-
         except Exception as e:
-            logger.error(f"Error estimating transaction for period {period.id}: {e}")
-            raise
+            logger.error(
+                "Error estimating transaction for period %s: %s", period.id, e
+            )
+            return None

--- a/core/signals.py
+++ b/core/signals.py
@@ -53,6 +53,19 @@ def clear_transaction_cache(sender, instance, **kwargs):
         delattr(clear_transaction_cache, '_processing')
 
 # 🚫 REMOVIDO: Armazenamento de dados para atualização automática de saldos
+@receiver(post_save, sender=Transaction)
+def remove_estimate_on_manual(sender, instance, created, **kwargs):
+    if instance.is_estimated:
+        return
+    if transaction.get_connection().in_atomic_block:
+        return
+    Transaction.objects.filter(
+        user=instance.user,
+        period=instance.period,
+        is_estimated=True,
+        type=instance.type,
+    ).delete()
+
 
 # 🚫 REMOVIDO: Signals que alteravam saldos automaticamente
 # Os saldos das contas devem ser controlados APENAS pelo utilizador

--- a/core/tests/test_finance_estimation.py
+++ b/core/tests/test_finance_estimation.py
@@ -1,0 +1,124 @@
+import json
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import RequestFactory
+from django.urls import reverse
+
+from core.models import (
+    Account,
+    AccountBalance,
+    DatePeriod,
+    Transaction,
+)
+from core.services.finance_estimation import FinanceEstimationService
+from core.views import get_estimation_summaries
+
+
+@pytest.mark.django_db
+def test_estimate_created_for_missing_period():
+    user = User.objects.create_user(username="u1", password="p")
+    account = Account.objects.create(user=user, name="Checking")
+
+    period1 = DatePeriod.objects.create(year=2024, month=1, label="January 2024")
+    period2 = DatePeriod.objects.create(year=2024, month=2, label="February 2024")
+
+    AccountBalance.objects.create(account=account, period=period1, reported_balance=Decimal("1000"))
+    AccountBalance.objects.create(account=account, period=period2, reported_balance=Decimal("1000"))
+
+    Transaction.objects.create(
+        user=user,
+        amount=Decimal("1000"),
+        type="IN",
+        date=date(2024, 1, 1),
+        period=period1,
+        account=account,
+    )
+
+    service = FinanceEstimationService(user)
+    est_tx = service.estimate_transaction_for_period(period1)
+    assert est_tx is not None
+    assert est_tx.is_estimated is True
+    assert est_tx.type == "EX"
+    assert est_tx.amount == Decimal("1000")
+
+
+@pytest.mark.django_db(transaction=True)
+def test_manual_transaction_deletes_estimate():
+    user = User.objects.create_user(username="u2", password="p")
+    account = Account.objects.create(user=user, name="Checking")
+
+    period1 = DatePeriod.objects.create(year=2024, month=1, label="January 2024")
+    period2 = DatePeriod.objects.create(year=2024, month=2, label="February 2024")
+
+    AccountBalance.objects.create(account=account, period=period1, reported_balance=Decimal("1000"))
+    AccountBalance.objects.create(account=account, period=period2, reported_balance=Decimal("1000"))
+
+    Transaction.objects.create(
+        user=user,
+        amount=Decimal("1000"),
+        type="IN",
+        date=date(2024, 1, 1),
+        period=period1,
+        account=account,
+    )
+
+    service = FinanceEstimationService(user)
+    service.estimate_transaction_for_period(period1)
+    assert Transaction.objects.filter(user=user, period=period1, is_estimated=True).count() == 1
+
+    Transaction.objects.create(
+        user=user,
+        amount=Decimal("1000"),
+        type="EX",
+        date=date(2024, 1, 5),
+        period=period1,
+        account=account,
+    )
+
+    assert Transaction.objects.filter(user=user, period=period1, is_estimated=True).count() == 0
+    assert service.estimate_transaction_for_period(period1) is None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_estimation_summaries_excludes_balanced_period():
+    user = User.objects.create_user(username="u3", password="p")
+    account = Account.objects.create(user=user, name="Checking")
+
+    period1 = DatePeriod.objects.create(year=2024, month=1, label="January 2024")
+    period2 = DatePeriod.objects.create(year=2024, month=2, label="February 2024")
+
+    AccountBalance.objects.create(account=account, period=period1, reported_balance=Decimal("1000"))
+    AccountBalance.objects.create(account=account, period=period2, reported_balance=Decimal("1000"))
+
+    Transaction.objects.create(
+        user=user,
+        amount=Decimal("1000"),
+        type="IN",
+        date=date(2024, 1, 1),
+        period=period1,
+        account=account,
+    )
+
+    service = FinanceEstimationService(user)
+    service.estimate_transaction_for_period(period1)
+    Transaction.objects.create(
+        user=user,
+        amount=Decimal("1000"),
+        type="EX",
+        date=date(2024, 1, 5),
+        period=period1,
+        account=account,
+    )
+
+    url = reverse("get_estimation_summaries")
+    factory = RequestFactory()
+    request = factory.get(url)
+    request.user = user
+    response = get_estimation_summaries(request)
+    assert response.status_code == 200
+    data = json.loads(response.content)
+    period_labels = [s['period'] for s in data['summaries']]
+    assert 'January 2024' not in period_labels

--- a/core/views.py
+++ b/core/views.py
@@ -3137,7 +3137,6 @@ def estimate_transaction_for_period(request):
 
         # Get updated summary data
         summary = estimation_service.get_estimation_summary(period)
-
         # Clear transaction cache
         clear_tx_cache(request.user.id, force=True)
 
@@ -3201,7 +3200,8 @@ def get_estimation_summaries(request):
         for period in periods_with_data:
             try:
                 summary = estimation_service.get_estimation_summary(period)
-                summaries.append(summary)
+                if summary["status"] != "balanced" or summary["has_estimated_transaction"]:
+                    summaries.append(summary)
                 logger.debug(f"Generated summary for period {period.label}: {summary['status']}")
             except Exception as period_error:
                 logger.error(f"Error processing period {period.id}: {period_error}")


### PR DESCRIPTION
## Summary
- consolidate FinanceEstimationService and ensure estimates are skipped/deleted when real transactions exist
- remove stale estimated transactions whenever a manual transaction is saved
- ignore balanced periods without estimates in estimation summaries

## Testing
- `SECRET_KEY=testsecret pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c9603cccc832cb0446529bfc4d1da