### PR TITLE
Ensure CSRF headers on dashboard API requests

### DIFF
--- a/core/static/core/js/http.js
+++ b/core/static/core/js/http.js
@@ -1,0 +1,50 @@
+// /core/static/core/js/http.js
+// Minimal helper to ensure cookies + CSRF header on non-GET requests.
+
+export function getCookie(name) {
+  // Robust cookie reader
+  const parts = document.cookie ? document.cookie.split('; ') : [];
+  for (let i = 0; i < parts.length; i++) {
+    const [k, ...rest] = parts[i].split('=');
+    if (k === name) return decodeURIComponent(rest.join('='));
+  }
+  // Fallback: try meta tag if cookie is HttpOnly or unavailable
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  return meta ? meta.getAttribute('content') : null;
+}
+
+export async function api(url, { method = 'GET', headers = {}, body } = {}) {
+  const opts = {
+    method,
+    credentials: 'same-origin',              // send cookies
+    headers: { 'X-Requested-With': 'XMLHttpRequest', ...headers },
+  };
+
+  // Attach CSRF on mutable requests
+  if (method !== 'GET' && method !== 'HEAD') {
+    const token = getCookie('csrftoken');
+    if (token) opts.headers['X-CSRFToken'] = token;
+    if (body && !(body instanceof FormData)) {
+      opts.headers['Content-Type'] = 'application/json';
+      opts.body = JSON.stringify(body);
+    } else {
+      opts.body = body ?? null;
+    }
+  } else {
+    // For GET/HEAD we still allow JSON convenience
+    if (body && !(body instanceof FormData)) {
+      opts.headers['Content-Type'] = 'application/json';
+      opts.body = JSON.stringify(body);
+    } else if (body) {
+      opts.body = body;
+    }
+  }
+
+  const res = await fetch(url, opts);
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`HTTP ${res.status} on ${url} :: ${text.slice(0, 300)}`);
+  }
+  const ct = res.headers.get('Content-Type') || '';
+  return ct.includes('application/json') ? res.json() : res.text();
+}

--- a/core/static/js/dashboard.js
+++ b/core/static/js/dashboard.js
@@ -1,3 +1,5 @@
+import { api } from '../core/js/http.js';
+
 // Enhanced Dashboard JavaScript with Advanced Charts and Analysis
 document.addEventListener("DOMContentLoaded", () => {
   // Global variables
@@ -1301,25 +1303,14 @@ document.addEventListener("DOMContentLoaded", () => {
           const monthInt = getMonthNumberInt(month);
           const lastDay = new Date(fullYear, monthInt, 0).getDate();
 
-          const response = await fetch('/transactions/totals-v2/', {
+          const data = await api('/transactions/totals-v2/', {
             method: 'POST',
-            credentials: 'same-origin',
-            headers: {
-              'Content-Type': 'application/json',
-              'X-CSRFToken': getCookie('csrftoken'),
-            },
-            body: JSON.stringify({
+            body: {
               date_start: `${fullYear}-${monthNum}-01`,
               date_end: `${fullYear}-${monthNum}-${lastDay}`,
               include_system: false  // Exclude system transactions for real user spending
-            })
+            }
           });
-
-          if (!response.ok) {
-            throw new Error(`API failed for period ${period}`);
-          }
-
-          const data = await response.json();
           console.log(`📊 [updateFlowsChart] ${period} data:`, data);
 
           return {
@@ -1556,25 +1547,20 @@ document.addEventListener("DOMContentLoaded", () => {
       const endDate = convertPeriodToDate(endPeriod);
 
       // Fetch real spending data by category
-      const response = await fetch('/dashboard/spending-by-category/', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': getCookie('csrftoken'),
-        },
-        body: JSON.stringify({
-          start_period: startDate,
-          end_period: endDate
-        })
-      });
-
-      if (!response.ok) {
+      let data;
+      try {
+        data = await api('/dashboard/spending-by-category/', {
+          method: 'POST',
+          body: {
+            start_period: startDate,
+            end_period: endDate
+          }
+        });
+      } catch (err) {
         console.warn('⚠️ [updateExpensesChart] API failed, using fallback data');
         updateExpensesChartFallback();
         return;
       }
-
-      const data = await response.json();
       console.log('📊 [updateExpensesChart] Real spending data received:', data);
 
       if (data.status === 'success' && data.categories && data.categories.length > 0) {
@@ -2535,45 +2521,20 @@ document.addEventListener("DOMContentLoaded", () => {
   // Function to synchronize system adjustments
   const syncSystemAdjustments = async () => {
     try {
-      const response = await fetch('/sync-system-adjustments/', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': getCookie('csrftoken'),
-        },
-      });
+      await api('/sync-system-adjustments/', { method: 'POST' });
 
-      if (response.ok) {
-        console.log('✅ System adjustments synchronized successfully.');
-        // Optionally, refresh the dashboard data after synchronization
-        await loadAccountBalances();
-        await loadFinancialKPIs();
-        await loadFinancialAnalysis();
-        updateDashboard();
-      } else {
-        console.error('❌ Failed to synchronize system adjustments:', response.statusText);
-      }
+      console.log('✅ System adjustments synchronized successfully.');
+      // Optionally, refresh the dashboard data after synchronization
+      await loadAccountBalances();
+      await loadFinancialKPIs();
+      await loadFinancialAnalysis();
+      updateDashboard();
     } catch (error) {
       console.error('❌ Error synchronizing system adjustments:', error);
     }
   };
 
-  // Function to get CSRF token from cookie
-  function getCookie(name) {
-    let cookieValue = null;
-    if (document.cookie && document.cookie !== '') {
-      const cookies = document.cookie.split(';');
-      for (let i = 0; i < cookies.length; i++) {
-        let cookie = cookies[i].trim();
-        // Does this cookie string begin with the name we want?
-        if (cookie.substring(0, name.length + 1) === (name + '=')) {
-          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-          break;
-        }
-      }
-    }
-    return cookieValue;
-  }
+  
 
   // Start the enhanced dashboard
   init();

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
+  {% csrf_token %}
   <meta name="csrf-token" content="{{ csrf_token }}">
 
   {% block extra_head %}{% endblock %}

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -788,5 +788,5 @@ Dashboard{% endblock %} {% block extra_head %}
     window.location.search = params.toString();
   });
 </script>
-<script src="{% static 'js/dashboard.js' %}"></script>
+<script type="module" src="{% static 'js/dashboard.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add reusable `api` helper that attaches CSRF token and cookies
- include CSRF token meta tag in base template
- refactor dashboard POST requests to use helper and ES module

## Testing
- `SECRET_KEY=test pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d078f1848832c8850a68631d06fd7