### PR TITLE
Validate referer on account deletion

### DIFF
--- a/accounts/tests/test_delete_account.py
+++ b/accounts/tests/test_delete_account.py
@@ -14,3 +14,20 @@ def test_delete_account_view(client, settings):
     })
     assert response.status_code == 200
     assert not User.objects.filter(username="tester").exists()
+
+
+@pytest.mark.django_db
+def test_delete_account_view_invalid_referer(client, settings):
+    settings.SECURE_SSL_REDIRECT = False
+    user = User.objects.create_user(username="tester", password="secret")
+    client.force_login(user)
+    response = client.post(
+        reverse("accounts:delete_account"),
+        {
+            "password": "wrong",
+            "confirmation": "DELETE",
+        },
+        HTTP_REFERER="http://evil.com",
+    )
+    assert response.status_code == 302
+    assert response.url == reverse("home") + "?delete_error=1"


### PR DESCRIPTION
## Summary
- validate DeleteAccountView error redirect using `url_has_allowed_host_and_scheme`
- add regression test ensuring external referers fall back to home

## Testing
- `pytest accounts/tests/test_delete_account.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3781b700832ca87068d11c5e8c0a