### PR TITLE
Use CSP nonces for inline scripts and styles

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -25,7 +25,7 @@
   <link rel="stylesheet" href="{% static 'css/main.css' %}">
 
     <!-- Project Color Overrides for Bootstrap -->
-    <style>
+    <style nonce="{{ request.csp_nonce }}">
         /* Bootstrap Component Overrides with Project Colors */
         .btn-primary {
             background-color: #3AB49E !important;
@@ -183,10 +183,10 @@
         }
     </style>
 </head>
-<body style="background-color: #f8f9fa;">
+<body class="bg-light">
 
 {% block navbar %}
-<nav class="navbar navbar-expand-lg navbar-light" style="background-color: #ffffff; border-bottom: 1px solid #ccc;" aria-label="Main navigation">
+<nav class="navbar navbar-expand-lg navbar-light" aria-label="Main navigation">
   <div class="container-fluid">
         <a class="navbar-brand d-flex align-items-center gap-2" href="{% url 'home' %}">
 
@@ -374,7 +374,7 @@
 <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js" defer></script>
 <script src="{% static 'js/main.js' %}" defer></script>
 
-<script>
+<script nonce="{{ request.csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
   const checkbox = document.getElementById('confirmDeleteCheckbox');
   const continueBtn = document.getElementById('deleteAccountContinue');

--- a/core/templates/core/account_list.html
+++ b/core/templates/core/account_list.html
@@ -48,12 +48,12 @@
   </div>
 
 <!-- CSRF token for JavaScript -->
-<div style="display: none;">
+<div class="d-none">
   {% csrf_token %}
 </div>
 
 <!-- Alternative CSRF token method -->
-<script>
+<script nonce="{{ request.csp_nonce }}">
   window.csrfToken = '{{ csrf_token }}';
 </script>
 

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -293,7 +293,7 @@ Dashboard{% endblock %} {% block extra_head %}
             </div>
 
             <!-- List View (Hidden by default) -->
-            <div id="list-view" style="display: none;">
+            <div id="list-view" class="d-none">
               <div class="row">
                 {% for item in charts %}
                 <div class="col-lg-6 mb-3">
@@ -342,7 +342,7 @@ Dashboard{% endblock %} {% block extra_head %}
   </div>
 
   <!-- Period Mode Specific Scripts -->
-  <script>
+  <script nonce="{{ request.csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
       console.log('🎯 Period mode dashboard loading...');
 
@@ -1007,7 +1007,7 @@ Dashboard{% endblock %} {% block extra_head %}
         </div>
         <div class="card-body chart-container">
           <canvas id="evolution-chart"></canvas>
-          <canvas id="returns-chart" style="display: none;"></canvas>
+          <canvas id="returns-chart" class="d-none"></canvas>
         </div>
       </div>
     </div>
@@ -1092,7 +1092,7 @@ Dashboard{% endblock %} {% block extra_head %}
 />
 <script src="https://cdn.jsdelivr.net/npm/nouislider@15.7.0/dist/nouislider.min.js"></script>
 
-<style>
+<style nonce="{{ request.csp_nonce }}">
   .card {
     box-shadow: 0 2px 8px rgba(36, 40, 44, 0.08) !important;
     border: 1px solid #D9DBDD !important;
@@ -1488,7 +1488,7 @@ Dashboard{% endblock %} {% block extra_head %}
     }
   }
 </style>
-<script>
+<script nonce="{{ request.csp_nonce }}">
   document.getElementById('historyBtn').addEventListener('click', function () {
     window.location.href = '/dashboard/?mode=history';
   });

--- a/core/templates/core/estimate_transactions.html
+++ b/core/templates/core/estimate_transactions.html
@@ -13,7 +13,7 @@
                 <div class="d-flex gap-2 align-items-center">
                     <div class="d-flex align-items-center gap-2">
                         <label for="year-filter" class="form-label mb-0">Year:</label>
-                        <select id="year-filter" class="form-select form-select-sm" style="width: auto;">
+                        <select id="year-filter" class="form-select form-select-sm w-auto">
                             <!-- Options will be populated by JavaScript -->
                         </select>
                     </div>
@@ -359,7 +359,7 @@
 {% endblock %}
 
 {% block extra_js %}
-<script>
+<script nonce="{{ request.csp_nonce }}">
     // Ensure jQuery is loaded and pass CSRF token to the EstimationManager
     window.csrfToken = '{{ csrf_token }}';
 </script>

--- a/core/templates/core/import_balances_form.html
+++ b/core/templates/core/import_balances_form.html
@@ -64,7 +64,7 @@
     </div>
   </form>
 
-  <script>
+  <script nonce="{{ request.csp_nonce }}">
   document.addEventListener('DOMContentLoaded', function() {
     const form = document.getElementById('import-form');
     const fileInput = document.getElementById('file');

--- a/core/templates/core/import_form.html
+++ b/core/templates/core/import_form.html
@@ -86,7 +86,7 @@
 <!-- Bootstrap JS (para alertas e botão fechar) -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
 
-<script>
+<script nonce="{{ request.csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     const form = document.querySelector('form');
     const importBtn = document.getElementById('import-btn');

--- a/core/templates/core/transaction_list_v2.html
+++ b/core/templates/core/transaction_list_v2.html
@@ -433,7 +433,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ request.csp_nonce }}">
   // Ensure CSRF token is available for AJAX calls
   window.csrfToken = "{{ csrf_token }}";
 </script>
@@ -451,7 +451,7 @@
 />
 
 <!-- Custom Styles -->
-<style>
+<style nonce="{{ request.csp_nonce }}">
   .sticky-top {
     position: sticky !important;
     top: 0;

--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -178,14 +178,12 @@ CSP_SCRIPT_SRC = (
     "https://code.jquery.com",
     "https://cdn.datatables.net",
     "https://cdnjs.cloudflare.com",
-    "'unsafe-inline'",
 )
 CSP_STYLE_SRC = (
     "'self'",
     "https://cdn.jsdelivr.net",
     "https://cdn.datatables.net",
     "https://cdnjs.cloudflare.com",
-    "'unsafe-inline'",
 )
 CSP_FONT_SRC = (
     "'self'",


### PR DESCRIPTION
## Summary
- Drop `'unsafe-inline'` from CSP script and style directives
- Add CSP nonces to inline `<script>` and `<style>` blocks
- Replace some inline style attributes with utility classes

## Testing
- `SECRET_KEY=testsecret pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d37887290832cb1dbbd226d2b159e