### PR TITLE
Use Supabase DB URL if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pip install -r requirements.txt
 
 # Copy and configure environment variables
 cp .env.example .env
-# edit values as needed
+# edit values as needed (set SUPABASE_DB_URL with your Supabase connection)
 
 # Create the database and apply migrations
 python manage.py migrate

--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -143,9 +143,9 @@ TEMPLATES = [
 ]
 
 # ────────────────────────────────────────────────────
-# Base de dados (Supabase prioritário; fallback SQLite)
+# Base de dados (Supabase prioritário via SUPABASE_DB_URL/DATABASE_URL; fallback SQLite)
 # ────────────────────────────────────────────────────
-SUPA_URL = ENV("DATABASE_URL")
+SUPA_URL = ENV("SUPABASE_DB_URL") or ENV("DATABASE_URL")
 if not SUPA_URL and ENV("DB_HOST"):
     SUPA_URL = (
         f"postgresql://{ENV('DB_USER')}:{ENV('DB_PASSWORD')}"


### PR DESCRIPTION
## Summary
- prefer SUPABASE_DB_URL for database configuration, falling back to DATABASE_URL or SQLite
- note SUPABASE_DB_URL in README setup instructions

## Testing
- `SUPABASE_DB_URL='' DATABASE_URL='' DB_HOST='' DB_USER='' DB_PASSWORD='' DB_NAME='' DB_PORT='' pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f43ac6b44832cae59f0d322084ab1