### PR TITLE
Add comprehensive tests for accounts and core views

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,9 @@ Use comma-separated values. For `EXTRA_CSRF_TRUSTED_ORIGINS`, each origin must i
 ## 📄 Licence
 
 Distributed under the MIT licence. See the `LICENSE` file for more details.
+
+## 🧪 Running tests
+
+```bash
+DATABASE_URL=sqlite:////tmp/testdb.sqlite3 pytest
+```

--- a/accounts/tests/test_activate_view.py
+++ b/accounts/tests/test_activate_view.py
@@ -1,0 +1,36 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+
+from accounts.tokens import generate_activation_token
+
+
+@pytest.mark.django_db
+def test_activate_view_with_valid_token(client, settings):
+    settings.SECURE_SSL_REDIRECT = False
+    user = User.objects.create_user(
+        username="newuser", email="new@example.com", password="pass", is_active=False
+    )
+    token = generate_activation_token(user)
+    uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
+
+    response = client.get(reverse("accounts:activate", kwargs={"uidb64": uidb64, "token": token}))
+    user.refresh_from_db()
+    assert response.status_code == 200
+    assert user.is_active
+
+
+@pytest.mark.django_db
+def test_activate_view_with_invalid_token(client, settings):
+    settings.SECURE_SSL_REDIRECT = False
+    user = User.objects.create_user(
+        username="newuser", email="new@example.com", password="pass", is_active=False
+    )
+    uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
+
+    response = client.get(reverse("accounts:activate", kwargs={"uidb64": uidb64, "token": "bad"}))
+    user.refresh_from_db()
+    assert response.status_code == 400
+    assert not user.is_active

--- a/accounts/tests/test_login_lockout.py
+++ b/accounts/tests/test_login_lockout.py
@@ -1,0 +1,32 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.core.cache import cache
+
+
+@pytest.mark.django_db
+def test_login_lockout_after_failures(client, settings):
+    settings.SECURE_SSL_REDIRECT = False
+    cache.clear()
+    User.objects.create_user(username="tester", password="secret")
+    url = reverse("accounts:login")
+    for _ in range(5):
+        client.post(url, {"username": "tester", "password": "wrong"})
+    response = client.post(url, {"username": "tester", "password": "wrong"})
+    assert response.status_code == 200
+    messages = list(response.context["messages"])
+    assert any("Account locked" in str(m) for m in messages)
+
+
+@pytest.mark.django_db
+def test_login_success_resets_failed_attempts(client, settings):
+    settings.SECURE_SSL_REDIRECT = False
+    cache.clear()
+    User.objects.create_user(username="tester", password="secret")
+    url = reverse("accounts:login")
+    for _ in range(4):
+        client.post(url, {"username": "tester", "password": "wrong"})
+    assert cache.get("failed_tester") == 4
+    response = client.post(url, {"username": "tester", "password": "secret"})
+    assert response.status_code == 302
+    assert cache.get("failed_tester") is None

--- a/accounts/tests/test_profile_view.py
+++ b/accounts/tests/test_profile_view.py
@@ -1,0 +1,21 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+
+@pytest.mark.django_db
+def test_profile_requires_login(client, settings):
+    settings.SECURE_SSL_REDIRECT = False
+    response = client.get(reverse("accounts:profile"))
+    assert response.status_code == 302
+    assert reverse("accounts:login") in response.url
+
+
+@pytest.mark.django_db
+def test_profile_renders_for_authenticated_user(client, settings):
+    settings.SECURE_SSL_REDIRECT = False
+    user = User.objects.create_user(username="tester", password="secret")
+    client.force_login(user)
+    response = client.get(reverse("accounts:profile"))
+    assert response.status_code == 200
+    assert "accounts/profile.html" in [t.name for t in response.templates]

--- a/accounts/tests/test_template_views.py
+++ b/accounts/tests/test_template_views.py
@@ -1,0 +1,35 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_login_page_renders(client):
+    response = client.get(reverse("accounts:login"))
+    assert response.status_code == 200
+    assert "accounts/login.html" in [t.name for t in response.templates]
+
+
+@pytest.mark.django_db
+def test_signup_page_renders(client):
+    response = client.get(reverse("accounts:signup"))
+    assert response.status_code == 200
+    assert "accounts/signup.html" in [t.name for t in response.templates]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_name", [
+    "accounts:password_reset",
+    "accounts:password_reset_done",
+    "accounts:password_reset_complete",
+])
+def test_password_reset_pages_render(client, url_name):
+    response = client.get(reverse(url_name))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_delete_account_page_requires_login(client, django_user_model):
+    user = django_user_model.objects.create_user(username="u", password="p")
+    client.force_login(user)
+    response = client.get(reverse("accounts:delete_account"))
+    assert response.status_code == 200

--- a/core/tests/test_home_view.py
+++ b/core/tests/test_home_view.py
@@ -1,0 +1,20 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+
+@pytest.mark.django_db
+def test_home_view_renders_for_anonymous(client, settings):
+    settings.SECURE_SSL_REDIRECT = False
+    response = client.get(reverse("home"))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_home_view_redirects_authenticated_user(client, settings):
+    settings.SECURE_SSL_REDIRECT = False
+    user = User.objects.create_user(username="tester", password="secret")
+    client.force_login(user)
+    response = client.get(reverse("home"))
+    assert response.status_code == 302
+    assert response.url.rstrip("/") == reverse("dashboard").strip("/")

--- a/core/tests/test_initial_data_fixture.py
+++ b/core/tests/test_initial_data_fixture.py
@@ -1,0 +1,10 @@
+import json
+from pathlib import Path
+
+
+def test_initial_data_fixture_is_valid_json():
+    fixture_path = Path("core/fixtures/initial_data.json")
+    with fixture_path.open() as f:
+        data = json.load(f)
+    assert isinstance(data, list)
+    assert all("model" in item for item in data)

--- a/core/tests/test_json_endpoints.py
+++ b/core/tests/test_json_endpoints.py
@@ -1,0 +1,25 @@
+import pytest
+from django.urls import reverse
+
+from core.models import DatePeriod
+
+
+@pytest.mark.django_db
+def test_menu_config_returns_username_and_links(client, django_user_model):
+    user = django_user_model.objects.create_user(username="u", password="p")
+    client.force_login(user)
+    response = client.get(reverse("menu_config"))
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "u"
+    assert any(link["name"] == "Dashboard" for link in data["links"])
+
+
+@pytest.mark.django_db
+def test_period_autocomplete_returns_matching_periods(client, django_user_model):
+    user = django_user_model.objects.create_user(username="u", password="p")
+    DatePeriod.objects.create(year=2024, month=1, label="2024-01")
+    client.force_login(user)
+    response = client.get(reverse("period_autocomplete"), {"term": "2024"})
+    assert response.status_code == 200
+    assert response.json() == ["2024-01"]

--- a/core/tests/test_template_views.py
+++ b/core/tests/test_template_views.py
@@ -1,0 +1,29 @@
+import pytest
+from django.urls import reverse
+from django.db import connection
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(connection.vendor == "sqlite", reason="Dashboard view uses PostgreSQL-specific SQL")
+def test_dashboard_page_render(client, django_user_model):
+    user = django_user_model.objects.create_user(username="u", password="p")
+    client.force_login(user)
+    response = client.get(reverse("dashboard"))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_name", [
+    "transaction_list_v2",
+    "account_list",
+    "account_balance",
+    "category_list",
+    "account_create",
+    "transaction_create",
+    "category_create",
+])
+def test_core_html_pages_render_for_authenticated_users(client, django_user_model, url_name):
+    user = django_user_model.objects.create_user(username="u", password="p")
+    client.force_login(user)
+    response = client.get(reverse(url_name))
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add activation, login lockout, profile and template view tests for accounts app
- verify home view behavior, JSON endpoints and HTML template rendering in core app
- document how to run the test suite

## Testing
- `DATABASE_URL=sqlite:////tmp/testdb.sqlite3 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f61f00108832c9a6b9dfe8fd73a36