### PR TITLE
Handle missing dashboard elements and relax dev CSP

### DIFF
--- a/core/static/js/dashboard.js
+++ b/core/static/js/dashboard.js
@@ -77,8 +77,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Enhanced chart initialization
   const initCharts = () => {
-    const ctx1 = document.getElementById('evolution-chart').getContext('2d');
-    const ctx2 = document.getElementById('allocation-chart').getContext('2d');
+    const evolutionCanvas = document.getElementById('evolution-chart');
+    const allocationCanvas = document.getElementById('allocation-chart');
+    if (!evolutionCanvas || !allocationCanvas) {
+      console.warn('⚠️ Chart canvas elements missing, skipping chart initialization');
+      return;
+    }
+    const ctx1 = evolutionCanvas.getContext('2d');
+    const ctx2 = allocationCanvas.getContext('2d');
 
     // Evolution Chart with enhanced features
     charts.evolution = new Chart(ctx1, {
@@ -625,8 +631,10 @@ document.addEventListener("DOMContentLoaded", () => {
         if (allYears && allYears.length > 0) {
           console.log('📅 [initializeSlidersWithData] Initializing year slider with years:', allYears);
           initYearSlider(allYears);
-          console.log('📅 [initializeSlidersWithData] Initializing period slider with periods:', fullPeriods?.length || 0);
-          initPeriodSlider(fullPeriods || [], true, 12);
+          if (periodSlider) {
+            console.log('📅 [initializeSlidersWithData] Initializing period slider with periods:', fullPeriods?.length || 0);
+            initPeriodSlider(fullPeriods || [], true, 12);
+          }
           updateYearRangeDisplay();
         } else {
           console.warn('⚠️ [initializeSlidersWithData] No years available, using current year');
@@ -635,7 +643,9 @@ document.addEventListener("DOMContentLoaded", () => {
           const currentMonth = new Date().getMonth();
           const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
           const currentPeriod = `${monthNames[currentMonth]}/${currentYear.toString().slice(-2)}`;
-          initPeriodSlider([currentPeriod], true, 1);
+          if (periodSlider) {
+            initPeriodSlider([currentPeriod], true, 1);
+          }
         }
       } else {
         console.log('ℹ️ [initializeSlidersWithData] Sliders already initialized');
@@ -1762,7 +1772,9 @@ document.addEventListener("DOMContentLoaded", () => {
         const y = 2000 + parseInt(p.split("/")[1]);
         return y >= selectedYearRange[0] && y <= selectedYearRange[1];
       });
-      initPeriodSlider(fullPeriods, true, 12);
+      if (periodSlider) {
+        initPeriodSlider(fullPeriods, true, 12);
+      }
       updateDashboard(); // Update dashboard when year range changes
     });
 

--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -259,7 +259,8 @@ if DEBUG:
     CSP_UPGRADE_INSECURE_REQUESTS = False
     CSP_CONNECT_SRC = ("'self'",) + CDN_HOSTS
     CSP_SCRIPT_SRC  = ("'self'",) + CDN_HOSTS
-    CSP_STYLE_SRC   = ("'self'",) + CDN_HOSTS
+    # Allow inline styles in development to simplify debugging templates
+    CSP_STYLE_SRC   = ("'self'", "'unsafe-inline'") + CDN_HOSTS
     CSP_IMG_SRC     = ("'self'", "data:")
     CSP_FONT_SRC    = ("'self'", "data:") + CDN_HOSTS
 


### PR DESCRIPTION
## Summary
- permit inline styles during development to avoid CSP violations while debugging
- guard dashboard chart and period slider init when DOM elements are absent

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f78ac6c54832cb6ee6c420d316ffc