### PR TITLE
Fix CSP and inline styles for dev vs prod

### DIFF
--- a/core/static/css/main.css
+++ b/core/static/css/main.css
@@ -1174,3 +1174,18 @@ button:hover,
 
 .kpi-card .progress { height: 4px; }
 .kpi-card .badge { font-size: .7rem; }
+
+/* Styles migrated from inline attributes */
+.kpi-muted { margin-top: 1rem; color: #666; }
+.min-w-150 { min-width: 150px; }
+.progress-thin { height: 6px; }
+.progress-xthin { height: 4px; }
+.w-0 { width: 0%; }
+.th-checkbox { width: 40px; padding: 0.75rem 0.5rem; text-align: center; }
+.fs-7 { font-size: 0.7rem; }
+.min-w-90 { min-width: 90px; }
+.min-w-100 { min-width: 100px; }
+.min-w-110 { min-width: 110px; }
+.min-w-120 { min-width: 120px; }
+.w-120 { width: 120px; }
+.p-075 { padding: 0.75rem; }

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -24,11 +24,10 @@ Dashboard{% endblock %} {% block extra_head %}
          title="Previous period">
         <i class="fas fa-chevron-left"></i>
       </a>
-      <input id="periodPicker" 
-             type="month" 
-             class="form-control form-control-sm" 
-             value="{{ period }}" 
-             style="min-width: 150px;">
+      <input id="periodPicker"
+             type="month"
+             class="form-control form-control-sm min-w-150"
+             value="{{ period }}">
       <a href="/dashboard/?mode=period&period={{ next_period }}" 
          class="btn btn-outline-secondary btn-sm" 
          aria-label="Next period"
@@ -208,10 +207,12 @@ Dashboard{% endblock %} {% block extra_head %}
                     {{ savings_rate }}%
                   </small>
                 </div>
-                <div class="progress" style="height: 6px;">
-                  <div class="progress-bar bg-{% if savings_rate > 20 %}success{% elif savings_rate > 10 %}warning{% else %}danger{% endif %}" 
-                       style="width: {% if savings_rate > 0 %}{{ savings_rate }}{% else %}0{% endif %}%"></div>
+                <div class="progress progress-thin">
+                  <div class="progress-bar bg-{% if savings_rate > 20 %}success{% elif savings_rate > 10 %}warning{% else %}danger{% endif %} savings-rate-bar"></div>
                 </div>
+                <style nonce="{{ request.csp_nonce }}">
+                  .savings-rate-bar { width: {% if savings_rate > 0 %}{{ savings_rate }}{% else %}0{% endif %}% }
+                </style>
               </div>
 
               {% widthratio kpis.investments kpis.income 100 as investment_rate %}
@@ -220,9 +221,12 @@ Dashboard{% endblock %} {% block extra_head %}
                   <small class="text-muted">Investment Rate</small>
                   <small class="fw-bold text-primary">{{ investment_rate }}%</small>
                 </div>
-                <div class="progress" style="height: 6px;">
-                  <div class="progress-bar bg-primary" style="width: {{ investment_rate }}%"></div>
+                <div class="progress progress-thin">
+                  <div class="progress-bar bg-primary investment-rate-bar"></div>
                 </div>
+                <style nonce="{{ request.csp_nonce }}">
+                  .investment-rate-bar { width: {{ investment_rate }}% }
+                </style>
               </div>
 
               {% if savings_rate > 20 %}
@@ -313,10 +317,13 @@ Dashboard{% endblock %} {% block extra_head %}
                           <span class="h5 mb-0 fw-bold text-danger">€ {{ item.total|floatformat:2 }}</span>
                         </div>
                       </div>
-                      <div class="progress mt-2" style="height: 6px;">
+                      <div class="progress mt-2 progress-thin">
                         {% if kpis.expenses > 0 %}
                         {% widthratio item.total kpis.expenses 100 as progress_pct %}
-                        <div class="progress-bar bg-danger" style="width: {{ progress_pct }}%"></div>
+                        <div class="progress-bar bg-danger category-progress-{{ forloop.counter }}"></div>
+                        <style nonce="{{ request.csp_nonce }}">
+                          .category-progress-{{ forloop.counter }} { width: {{ progress_pct }}% }
+                        </style>
                         {% endif %}
                       </div>
                     </div>
@@ -866,11 +873,10 @@ Dashboard{% endblock %} {% block extra_head %}
             </div>
             <i class="fas fa-arrow-up fa-2x text-success opacity-25"></i>
           </div>
-          <div class="progress mt-2" style="height: 4px">
+          <div class="progress mt-2 progress-xthin">
             <div
-              class="progress-bar bg-success"
+              class="progress-bar bg-success w-0"
               id="receita-progress"
-              style="width: 0%"
             ></div>
           </div>
           <small class="text-muted mt-1 d-block" id="receita-change">-</small>
@@ -888,11 +894,10 @@ Dashboard{% endblock %} {% block extra_head %}
             </div>
             <i class="fas fa-arrow-down fa-2x text-danger opacity-25"></i>
           </div>
-          <div class="progress mt-2" style="height: 4px">
+          <div class="progress mt-2 progress-xthin">
             <div
-              class="progress-bar bg-danger"
+              class="progress-bar bg-danger w-0"
               id="despesa-progress"
-              style="width: 0%"
             ></div>
           </div>
           <small class="text-muted mt-1 d-block" id="despesa-change">-</small>
@@ -918,11 +923,10 @@ Dashboard{% endblock %} {% block extra_head %}
             </div>
             <i class="fas fa-chart-line fa-2x text-info opacity-25"></i>
           </div>
-          <div class="progress mt-2" style="height: 4px">
+          <div class="progress mt-2 progress-xthin">
             <div
-              class="progress-bar bg-info"
+              class="progress-bar bg-info w-0"
               id="investido-progress"
-              style="width: 0%"
             ></div>
           </div>
           <small class="text-muted mt-1 d-block" id="investido-change">-</small>
@@ -940,11 +944,10 @@ Dashboard{% endblock %} {% block extra_head %}
             </div>
             <i class="fas fa-gem fa-2x text-purple opacity-25"></i>
           </div>
-          <div class="progress mt-2" style="height: 4px">
+          <div class="progress mt-2 progress-xthin">
             <div
-              class="progress-bar bg-purple"
+              class="progress-bar bg-purple w-0"
               id="patrimonio-progress"
-              style="width: 0%"
             ></div>
           </div>
           <small class="text-muted mt-1 d-block" id="patrimonio-change"
@@ -964,11 +967,10 @@ Dashboard{% endblock %} {% block extra_head %}
             </div>
             <i class="fas fa-percent fa-2x text-dark opacity-25"></i>
           </div>
-          <div class="progress mt-2" style="height: 4px">
+          <div class="progress mt-2 progress-xthin">
             <div
-              class="progress-bar bg-dark"
+              class="progress-bar bg-dark w-0"
               id="poupanca-progress"
-              style="width: 0%"
             ></div>
           </div>
           <small class="text-muted mt-1 d-block" id="poupanca-change">-</small>

--- a/core/templates/core/partials/kpi_card.html
+++ b/core/templates/core/partials/kpi_card.html
@@ -10,9 +10,14 @@
       </div>
       {% if icon %}{{ icon|safe }}{% endif %}
     </div>
-    <div class="progress mt-2" style="height: 4px">
-      <div class="progress-bar {{ progress_bar_class }}"{% if progress_id %} id="{{ progress_id }}"{% endif %} style="width: {{ meter }}%"></div>
+    <div class="progress mt-2 progress-xthin">
+      <div class="progress-bar {{ progress_bar_class }}"{% if progress_id %} id="{{ progress_id }}"{% endif %}></div>
     </div>
+    {% if progress_id %}
+    <style nonce="{{ request.csp_nonce }}">#{{ progress_id }} { width: {{ meter }}%; }</style>
+    {% else %}
+    <style nonce="{{ request.csp_nonce }}">.kpi-progress-bar { width: {{ meter }}%; }</style>
+    {% endif %}
     {% if footer %}
     <small class="text-muted mt-1 d-block"{% if footer_id %} id="{{ footer_id }}"{% endif %}>
       {% if footer_badge_class %}<span class="{{ footer_badge_class }}">{{ footer }}</span>{% else %}{{ footer }}{% endif %}

--- a/core/templates/core/transaction_list_v2.html
+++ b/core/templates/core/transaction_list_v2.html
@@ -255,8 +255,7 @@
         <label class="form-label mb-0 fw-bold">📄 Show:</label>
         <select
           id="page-size-selector"
-          class="form-select form-select-sm"
-          style="width: auto"
+          class="form-select form-select-sm w-auto"
         >
           <option value="25">25 per page</option>
           <option value="50">50 per page</option>
@@ -307,16 +306,15 @@
         <table id="transactions-table" class="table table-hover mb-0 table-sm">
           <thead class="table-dark sticky-top">
             <tr class="text-nowrap">
-              <th style="width: 40px; padding: 0.75rem 0.5rem; text-align: center;">
+              <th class="th-checkbox">
                 <input
                   type="checkbox"
-                  class="form-check-input"
+                  class="form-check-input d-none"
                   id="select-all"
-                  style="display: none"
                 />
-                <span class="badge bg-secondary" style="font-size: 0.7rem;">#</span>
+                <span class="badge bg-secondary fs-7">#</span>
               </th>
-              <th class="sortable-header" data-sort="date" style="min-width: 110px; padding: 0.75rem;">
+              <th class="sortable-header min-w-110 p-075" data-sort="date">
                 <div class="d-flex align-items-center">
                   <span class="me-1">📅</span>
                   <span class="d-none d-sm-inline">Date</span>
@@ -324,9 +322,8 @@
                 </div>
               </th>
               <th
-                class="d-none d-md-table-cell sortable-header"
+                class="d-none d-md-table-cell sortable-header min-w-100 p-075"
                 data-sort="period"
-                style="min-width: 100px; padding: 0.75rem;"
               >
                 <div class="d-flex align-items-center">
                   <span class="me-1">📆</span>
@@ -334,14 +331,14 @@
                   <i class="fas fa-sort sort-icon ms-1"></i>
                 </div>
               </th>
-              <th class="sortable-header" data-sort="type" style="min-width: 90px; padding: 0.75rem;">
+              <th class="sortable-header min-w-90 p-075" data-sort="type">
                 <div class="d-flex align-items-center">
                   <span class="me-1">📊</span>
                   <span class="d-none d-sm-inline">Type</span>
                   <i class="fas fa-sort sort-icon ms-1"></i>
                 </div>
               </th>
-              <th class="sortable-header text-end" data-sort="amount" style="min-width: 120px; padding: 0.75rem;">
+              <th class="sortable-header text-end min-w-120 p-075" data-sort="amount">
                 <div class="d-flex align-items-center justify-content-end">
                   <span class="me-1">💰</span>
                   <span>Amount</span>
@@ -349,9 +346,8 @@
                 </div>
               </th>
               <th
-                class="d-none d-lg-table-cell sortable-header"
+                class="d-none d-lg-table-cell sortable-header min-w-120 p-075"
                 data-sort="category"
-                style="min-width: 120px; padding: 0.75rem;"
               >
                 <div class="d-flex align-items-center">
                   <span class="me-1">🏷️</span>
@@ -360,9 +356,8 @@
                 </div>
               </th>
               <th
-                class="d-none d-xl-table-cell sortable-header"
+                class="d-none d-xl-table-cell sortable-header min-w-100 p-075"
                 data-sort="tags"
-                style="min-width: 100px; padding: 0.75rem;"
               >
                 <div class="d-flex align-items-center">
                   <span class="me-1">🏷️</span>
@@ -371,9 +366,8 @@
                 </div>
               </th>
               <th
-                class="d-none d-md-table-cell sortable-header"
+                class="d-none d-md-table-cell sortable-header min-w-100 p-075"
                 data-sort="account"
-                style="min-width: 100px; padding: 0.75rem;"
               >
                 <div class="d-flex align-items-center">
                   <span class="me-1">🏦</span>
@@ -381,7 +375,7 @@
                   <i class="fas fa-sort sort-icon ms-1"></i>
                 </div>
               </th>
-              <th style="width: 120px; padding: 0.75rem; text-align: center;">
+              <th class="w-120 p-075 text-center">
                 <div class="d-flex align-items-center justify-content-center">
                   <span class="me-1">⚙️</span>
                   <span class="d-none d-sm-inline">Actions</span>

--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -231,15 +231,20 @@ AUTH_PASSWORD_VALIDATORS = [
 # Security profiles (DEV/PROD): HTTPS, Cookies/CSRF e CSP
 # ────────────────────────────────────────────────────
 # CSP baseline + CDNs
-CSP_DEFAULT_SRC = ("'self'",)
 CDN_HOSTS = (
     "https://cdn.jsdelivr.net",
     "https://cdn.datatables.net",
     "https://cdnjs.cloudflare.com",
     "https://code.jquery.com",
 )
+CSP_DEFAULT_SRC = ("'self'",)
+CSP_SCRIPT_SRC = ("'self'",) + CDN_HOSTS
+CSP_STYLE_SRC = ("'self'",) + CDN_HOSTS
+CSP_CONNECT_SRC = ("'self'",) + CDN_HOSTS
+CSP_IMG_SRC = ("'self'", "data:")
+CSP_FONT_SRC = ("'self'", "data:") + CDN_HOSTS
 # ✅ Gera nonce automaticamente em <script> e <style> via request.csp_nonce
-CSP_NONCE_IN = ["script-src", "style-src"]
+CSP_INCLUDE_NONCE_IN = ["script-src", "style-src"]
 
 if DEBUG:
     # Dev: sem HTTPS forçado
@@ -255,13 +260,9 @@ if DEBUG:
     CSRF_USE_SESSIONS = False
     CSRF_FAILURE_VIEW = "django.views.csrf.csrf_failure"
 
-    # CSP em DEV: mesmos requisitos de PROD, usando sempre nonces
+    # CSP em DEV
     CSP_UPGRADE_INSECURE_REQUESTS = False
-    CSP_CONNECT_SRC = ("'self'",) + CDN_HOSTS
-    CSP_SCRIPT_SRC  = ("'self'",) + CDN_HOSTS
-    CSP_STYLE_SRC   = ("'self'",) + CDN_HOSTS
-    CSP_IMG_SRC     = ("'self'", "data:")
-    CSP_FONT_SRC    = ("'self'", "data:") + CDN_HOSTS
+    CSP_STYLE_SRC = CSP_STYLE_SRC + ("'unsafe-inline'",)
 
     # Origens confiáveis (HTTP + portas)
     CSRF_TRUSTED_ORIGINS = [
@@ -290,12 +291,7 @@ else:
 
     # CSP em PROD (sem inline; usa nonces nos <script>/<style> que precisares)
     CSP_UPGRADE_INSECURE_REQUESTS = True
-    CSP_CONNECT_SRC = ("'self'",) + CDN_HOSTS
-    CSP_SCRIPT_SRC  = ("'self'",) + CDN_HOSTS
-    CSP_STYLE_SRC   = ("'self'",) + CDN_HOSTS
-    CSP_IMG_SRC     = ("'self'", "data:")
-    CSP_FONT_SRC    = ("'self'", "data:") + CDN_HOSTS
-    # Se precisares de inline controlado, mantém nonces: CSP_NONCE_IN acima.
+    # Se precisares de inline controlado, usa nonces: CSP_INCLUDE_NONCE_IN acima.
 
 # ────────────────────────────────────────────────────
 # Email


### PR DESCRIPTION
## Summary
- centralize CSP settings with nonce support and dev/prod overrides
- replace inline styles with classes and nonced blocks across dashboard and tables
- add CSS helpers for min-widths and slim progress bars

## Testing
- `SECRET_KEY=test pytest` *(fails: assert 301 == 200, assert 429 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_689f8053f1bc832c89ce886d44b33502