### PR TITLE
Fix CSP nonce configuration and boolean directives

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -30,12 +30,16 @@ class CSPMiddleware:
         for attr in dir(settings):
             if not attr.startswith("CSP_"):
                 continue
-            if attr in {"CSP_NONCE_IN"}:  # helper settings - not directives
+            # Helper settings that shouldn't become directives
+            if attr in {"CSP_NONCE_IN", "CSP_INCLUDE_NONCE_IN"}:
                 continue
             directive = attr[4:].replace("_", "-").lower()
             self._directive_settings[directive] = getattr(settings, attr)
 
-        nonce_in = getattr(settings, "CSP_NONCE_IN", [])
+        # ``CSP_NONCE_IN`` is the canonical setting, but support the old
+        # ``CSP_INCLUDE_NONCE_IN`` for backwards compatibility.
+        nonce_in = list(getattr(settings, "CSP_NONCE_IN", []))
+        nonce_in += list(getattr(settings, "CSP_INCLUDE_NONCE_IN", []))
         self._nonce_directives = {
             d.replace("_", "-").lower() for d in nonce_in
         }

--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -244,7 +244,9 @@ CSP_CONNECT_SRC = ("'self'",) + CDN_HOSTS
 CSP_IMG_SRC = ("'self'", "data:")
 CSP_FONT_SRC = ("'self'", "data:") + CDN_HOSTS
 # ✅ Gera nonce automaticamente em <script> e <style> via request.csp_nonce
-CSP_INCLUDE_NONCE_IN = ["script-src", "style-src"]
+#    Usado por ``csp.middleware.CSPMiddleware`` para aplicar nonces às
+#    diretivas listadas sem gerar diretivas inválidas como ``nonce-in``.
+CSP_NONCE_IN = ["script-src", "style-src"]
 
 if DEBUG:
     # Dev: sem HTTPS forçado
@@ -291,7 +293,7 @@ else:
 
     # CSP em PROD (sem inline; usa nonces nos <script>/<style> que precisares)
     CSP_UPGRADE_INSECURE_REQUESTS = True
-    # Se precisares de inline controlado, usa nonces: CSP_INCLUDE_NONCE_IN acima.
+    # Se precisares de inline controlado, usa nonces: ``CSP_NONCE_IN`` acima.
 
 # ────────────────────────────────────────────────────
 # Email


### PR DESCRIPTION
## Summary
- use `CSP_NONCE_IN` setting to properly attach nonces and avoid bogus directives
- harden CSP middleware to ignore helper settings and support legacy `CSP_INCLUDE_NONCE_IN`

## Testing
- `DATABASE_URL=sqlite:////tmp/testdb.sqlite3 pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f839f6ce4832c9d685ad2af07f6fc