### PR TITLE
Disable secure redirects and inline styles CSP in DEBUG

### DIFF
--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -237,15 +237,18 @@ CDN_HOSTS = (
     "https://cdnjs.cloudflare.com",
     "https://code.jquery.com",
 )
-CSP_DEFAULT_SRC = ("'self'",)
-CSP_SCRIPT_SRC = ("'self'",) + CDN_HOSTS
-CSP_STYLE_SRC = ("'self'",) + CDN_HOSTS
-CSP_CONNECT_SRC = ("'self'",) + CDN_HOSTS
-CSP_IMG_SRC = ("'self'", "data:")
-CSP_FONT_SRC = ("'self'", "data:") + CDN_HOSTS
-# ✅ Gera nonce automaticamente em <script> e <style> via request.csp_nonce
+
+# --- CSP base (safe defaults) ---
+CSP_DEFAULT_SRC = globals().get("CSP_DEFAULT_SRC", ("'self'",))
+CSP_SCRIPT_SRC = globals().get("CSP_SCRIPT_SRC", ("'self'",) + CDN_HOSTS)
+CSP_STYLE_SRC = globals().get("CSP_STYLE_SRC", ("'self'",) + CDN_HOSTS)
+CSP_CONNECT_SRC = globals().get("CSP_CONNECT_SRC", ("'self'",) + CDN_HOSTS)
+CSP_IMG_SRC = globals().get("CSP_IMG_SRC", ("'self'", "data:"))
+CSP_FONT_SRC = globals().get("CSP_FONT_SRC", ("'self'", "data:") + CDN_HOSTS)
+# Enable nonces for script/style blocks (harmless if unused in templates)
 CSP_INCLUDE_NONCE_IN = ["script-src", "style-src"]
 
+# --- Environment-specific toggles ---
 if DEBUG:
     # Dev: sem HTTPS forçado
     SECURE_SSL_REDIRECT = False
@@ -262,7 +265,10 @@ if DEBUG:
 
     # CSP em DEV
     CSP_UPGRADE_INSECURE_REQUESTS = False
-    CSP_STYLE_SRC = CSP_STYLE_SRC + ("'unsafe-inline'",)
+
+    # Allow inline style attributes only in DEBUG to avoid CSP violations
+    if "'unsafe-inline'" not in CSP_STYLE_SRC:
+        CSP_STYLE_SRC = CSP_STYLE_SRC + ("'unsafe-inline'",)
 
     # Origens confiáveis (HTTP + portas)
     CSRF_TRUSTED_ORIGINS = [


### PR DESCRIPTION
## Summary
- initialize CSP defaults with CDN hosts and nonce support
- in DEBUG, disable SSL redirects and allow inline styles without upgrade-insecure-requests

## Testing
- `DATABASE_URL='' SUPABASE_DB_URL='' DB_HOST='' DB_USER='' DB_PASSWORD='' DB_NAME='' python manage.py runserver` (fails: network unreachable due to missing DB)
- `DATABASE_URL='' SUPABASE_DB_URL='' DB_HOST='' DB_USER='' DB_PASSWORD='' DB_NAME='' timeout 5 python manage.py runserver`
- `DATABASE_URL='' SUPABASE_DB_URL='' DB_HOST='' DB_USER='' DB_PASSWORD='' DB_NAME='' pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f84119110832c9e0011a954ecec59