### PR TITLE
Disable HTTPS forcing in development

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -31,7 +31,7 @@ class CSPMiddleware:
             if not attr.startswith("CSP_"):
                 continue
             # Helper settings that shouldn't become directives
-            if attr in {"CSP_NONCE_IN", "CSP_INCLUDE_NONCE_IN"}:
+            if attr in {"CSP_NONCE_IN", "CSP_INCLUDE_NONCE_IN", "CSP_UPGRADE_INSECURE_REQUESTS"}:
                 continue
             directive = attr[4:].replace("_", "-").lower()
             self._directive_settings[directive] = getattr(settings, attr)
@@ -62,6 +62,10 @@ class CSPMiddleware:
                 sources.append(f"'nonce-{nonce}'")
 
             directives.append(f"{directive} {' '.join(sources)}".strip())
+
+        flag = getattr(settings, "CSP_UPGRADE_INSECURE_REQUESTS", False)
+        if flag is True:
+            directives.append("upgrade-insecure-requests")
 
         return "; ".join(directives)
 


### PR DESCRIPTION
## Summary
- normalize DEBUG and CSP_UPGRADE_INSECURE_REQUESTS env vars to true booleans
- add final dev overrides to disable HTTPS redirects, cookies, CSP upgrade, and HSTS
- ensure CSP middleware only emits upgrade-insecure-requests when explicitly True

## Testing
- `pytest -q` *(fails: connection to server at "aws-0-eu-west-2.pooler.supabase.com" (18.135.253.94), port 6543 failed: Network is unreachable)*
- `pytest accounts/tests/test_activate_view.py::test_activate_view_with_valid_token -q` *(fails: connection to server at "aws-0-eu-west-2.pooler.supabase.com" (18.169.213.251), port 6543 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f87a6e020832caf6746885cac80c2