### PR TITLE
fix: generate per-request CSP nonces and secure login

### DIFF
--- a/accounts/templates/accounts/login.html
+++ b/accounts/templates/accounts/login.html
@@ -58,3 +58,14 @@
     </div>
 </div>
 {% endblock %}
+
+{% block extra_js %}
+<script nonce="{{ request.csp_nonce }}">
+document.addEventListener('DOMContentLoaded', function() {
+    const usernameField = document.getElementById('{{ form.username.id_for_label }}');
+    if (usernameField) {
+        usernameField.focus();
+    }
+});
+</script>
+{% endblock %}

--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -1,83 +1,49 @@
-"""Lightweight middleware to emit a Content-Security-Policy header.
-
-This project uses a very small subset of ``django-csp``.  The original
-implementation simply exposed every ``CSP_*`` setting as a directive which
-caused a couple of issues in production:
-
-* helper settings such as ``CSP_NONCE_IN`` were turned into bogus directives
-  (``nonce-in``);
-* boolean directives like ``upgrade-insecure-requests`` were emitted with the
-  string ``True`` as their value;
-* there was no support for per-request nonces to allow safe inline code.
-
-The middleware below fixes those problems while keeping the configuration
-style used in the project.
-"""
-
-from secrets import token_urlsafe
-
+import os
+import base64
 from django.conf import settings
 
 
 class CSPMiddleware:
-    """Apply Content Security Policy headers based on settings."""
-
     def __init__(self, get_response):
         self.get_response = get_response
 
-        # Collect all ``CSP_*`` settings that map directly to CSP directives.
-        self._directive_settings = {}
-        for attr in dir(settings):
-            if not attr.startswith("CSP_"):
-                continue
-            # Helper settings that shouldn't become directives
-            if attr in {"CSP_NONCE_IN", "CSP_INCLUDE_NONCE_IN", "CSP_UPGRADE_INSECURE_REQUESTS"}:
-                continue
-            directive = attr[4:].replace("_", "-").lower()
-            self._directive_settings[directive] = getattr(settings, attr)
-
-        # ``CSP_NONCE_IN`` is the canonical setting, but support the old
-        # ``CSP_INCLUDE_NONCE_IN`` for backwards compatibility.
-        nonce_in = list(getattr(settings, "CSP_NONCE_IN", []))
-        nonce_in += list(getattr(settings, "CSP_INCLUDE_NONCE_IN", []))
-        self._nonce_directives = {
-            d.replace("_", "-").lower() for d in nonce_in
-        }
-
-    def _build_header(self, nonce: str | None) -> str:
-        directives: list[str] = []
-        for directive, value in self._directive_settings.items():
-            # Boolean directives are included without a value when True.
-            if isinstance(value, bool):
-                if value:
-                    directives.append(directive)
-                continue
-
-            if isinstance(value, (list, tuple, set)):
-                sources = list(value)
-            else:
-                sources = [value]
-
-            if nonce and directive in self._nonce_directives:
-                sources.append(f"'nonce-{nonce}'")
-
-            directives.append(f"{directive} {' '.join(sources)}".strip())
-
-        flag = getattr(settings, "CSP_UPGRADE_INSECURE_REQUESTS", False)
-        if flag is True:
-            directives.append("upgrade-insecure-requests")
-
-        return "; ".join(directives)
-
     def __call__(self, request):
-        nonce = None
-        if self._nonce_directives:
-            nonce = token_urlsafe(16)
-            request.csp_nonce = nonce
-
-        header_value = self._build_header(nonce)
+        # per-request nonce
+        nonce = base64.b64encode(os.urandom(16)).decode("ascii")
+        request.csp_nonce = nonce
 
         response = self.get_response(request)
-        if header_value:
-            response["Content-Security-Policy"] = header_value
+
+        # Build policy from settings.* (whitelist known directives only)
+        policy = {
+            "default-src": getattr(settings, "CSP_DEFAULT_SRC", ("'self'",)),
+            "script-src": getattr(settings, "CSP_SCRIPT_SRC", ("'self'",)),
+            "style-src": getattr(settings, "CSP_STYLE_SRC", ("'self'",)),
+            "img-src": getattr(settings, "CSP_IMG_SRC", ("'self'", "data:")),
+            "connect-src": getattr(settings, "CSP_CONNECT_SRC", ("'self'",)),
+            "font-src": getattr(settings, "CSP_FONT_SRC", ("'self'", "data:")),
+            "frame-src": getattr(settings, "CSP_FRAME_SRC", ()),
+        }
+
+        # Conditionally add the nonce to script/style src lists
+        include_nonce_in = getattr(settings, "CSP_INCLUDE_NONCE_IN", ["script-src", "style-src"])
+        for key in include_nonce_in:
+            if key in policy:
+                policy[key] = tuple(policy[key]) + (f"'nonce-{nonce}'",)
+
+        # Assemble header string (semicolon-separated). DO NOT add any bogus tokens like 'nonce-in'.
+        csp_parts = []
+        for directive, sources in policy.items():
+            if sources:
+                csp_parts.append(f"{directive} {' '.join(sources)}")
+
+        # Add 'upgrade-insecure-requests' as a valueless directive when enabled
+        flag = getattr(settings, "CSP_UPGRADE_INSECURE_REQUESTS", False)
+        if flag is True:
+            csp_parts.append("upgrade-insecure-requests")
+
+        # Set header
+        if csp_parts:
+            response.headers["Content-Security-Policy"] = "; ".join(csp_parts)
+
         return response

--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -33,9 +33,10 @@ DEBUG: bool = env_bool("DEBUG")
 if isinstance(DEBUG, str):
     DEBUG = bool(strtobool(DEBUG))
 
-val = globals().get("CSP_UPGRADE_INSECURE_REQUESTS", False)
-if isinstance(val, str):
-    CSP_UPGRADE_INSECURE_REQUESTS = bool(strtobool(val))
+def _to_bool(v):
+    return v if isinstance(v, bool) else bool(strtobool(str(v)))
+
+CSP_UPGRADE_INSECURE_REQUESTS = _to_bool(globals().get("CSP_UPGRADE_INSECURE_REQUESTS", False))
 
 SECRET_KEY = ENV("SECRET_KEY")
 if not SECRET_KEY:
@@ -255,7 +256,7 @@ CSP_FONT_SRC = ("'self'", "data:") + CDN_HOSTS
 # ✅ Gera nonce automaticamente em <script> e <style> via request.csp_nonce
 #    Usado por ``csp.middleware.CSPMiddleware`` para aplicar nonces às
 #    diretivas listadas sem gerar diretivas inválidas como ``nonce-in``.
-CSP_NONCE_IN = ["script-src", "style-src"]
+CSP_INCLUDE_NONCE_IN = ["script-src", "style-src"]
 
 if DEBUG:
     # Dev: sem HTTPS forçado
@@ -302,7 +303,7 @@ else:
 
     # CSP em PROD (sem inline; usa nonces nos <script>/<style> que precisares)
     CSP_UPGRADE_INSECURE_REQUESTS = True
-    # Se precisares de inline controlado, usa nonces: ``CSP_NONCE_IN`` acima.
+    # Se precisares de inline controlado, usa nonces: ``CSP_INCLUDE_NONCE_IN`` acima.
 
 # ────────────────────────────────────────────────────
 # Email


### PR DESCRIPTION
## Summary
- build Content-Security-Policy header from whitelisted directives with per-request nonce
- ensure settings convert CSP_UPGRADE_INSECURE_REQUESTS to boolean and include nonce support
- focus login form username using nonce-aware inline script

## Testing
- `pytest` *(fails: django.db.utils.OperationalError: connection to server at "localhost" (127.0.0.1) refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f8aa8ef34832c872585f6fcf069fc