### PR TITLE
chore: remove inline styles for CSP

### DIFF
--- a/core/static/css/main.css
+++ b/core/static/css/main.css
@@ -1203,3 +1203,4 @@ button:hover,
 .modal-narrow { max-width: 400px; }
 .modal-rounded { border-radius: 8px; }
 .delete-confirm-text { font-size: 16px; color: #333; }
+.toast-high { z-index: 9999; }

--- a/core/static/js/account_balance.js
+++ b/core/static/js/account_balance.js
@@ -140,10 +140,10 @@ function addRow() {
           <table class="table table-hover mb-0">
             <thead class="table-light">
               <tr>
-                <th style="width: 40px;" class="text-center">📱</th>
+                <th class="text-center w-40">📱</th>
                 <th>Account Name</th>
-                <th class="text-end" style="width: 180px;">Balance</th>
-                <th style="width: 60px;" class="text-center">Actions</th>
+                <th class="text-end w-180">Balance</th>
+                <th class="text-center w-60">Actions</th>
               </tr>
             </thead>
             <tbody class="sortable-table" id="balance-table" data-reorder-url="/account-reorder/">

--- a/core/static/js/dashboard.js
+++ b/core/static/js/dashboard.js
@@ -1704,11 +1704,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Render insights with animations
     container.innerHTML = insights.map((insight, index) => `
-      <div class="insight-item insight-${insight.type}" style="animation-delay: ${index * 0.1}s;">
+      <div class="insight-item insight-${insight.type}" data-delay="${index * 0.1}s">
         <h6 class="mb-2">${insight.title}</h6>
         <p class="mb-0">${insight.text}</p>
       </div>
     `).join('');
+    container.querySelectorAll('.insight-item').forEach(item => {
+      item.style.animationDelay = item.dataset.delay;
+    });
   };
 
   // Enhanced slider initialization functions with better UX

--- a/core/static/js/estimate_transactions.js
+++ b/core/static/js/estimate_transactions.js
@@ -498,7 +498,7 @@ class EstimationManager {
     showToast(message, type, delay = 3000) {
         const toastId = `toast-${Date.now()}`;
         const toast = $(`
-            <div class="toast position-fixed top-0 end-0 m-3" id="${toastId}" style="z-index: 9999;">
+            <div class="toast position-fixed top-0 end-0 m-3 toast-high" id="${toastId}">
                 <div class="toast-body bg-${type} text-white">
                     ${message}
                 </div>

--- a/core/static/js/transaction_list_v2.js
+++ b/core/static/js/transaction_list_v2.js
@@ -863,11 +863,11 @@ class TransactionManager {
     }
 
     // Sempre criar a coluna do checkbox, mas controlar visibilidade
-    const checkboxVisibility = this.bulkMode ? "" : 'style="display: none;"';
+    const checkboxClass = this.bulkMode ? "" : " d-none";
 
     return `
       <tr data-id="${tx.id}" class="${rowClass}">
-        <td ${checkboxVisibility} class="text-center">
+        <td class="text-center${checkboxClass}">
           <input type="checkbox" class="form-check-input row-select" value="${tx.id}" ${isSelected ? "checked" : ""}>
         </td>
         <td class="text-nowrap">${formatDate(tx.date)}</td>
@@ -1530,7 +1530,7 @@ class TransactionManager {
   showToast(message, type, delay = 3000) {
     const toastId = `toast-${Date.now()}-${Math.random()}`;
     const toast = $(`
-      <div class="toast position-fixed top-0 end-0 m-3" id="${toastId}" style="z-index: 9999;">
+      <div class="toast position-fixed top-0 end-0 m-3 toast-high" id="${toastId}">
         <div class="toast-body bg-${type} text-white">
           ${message}
         </div>
@@ -1562,9 +1562,9 @@ class TransactionManager {
               </h5>
             </div>
             <div class="modal-body text-center">
-              <div class="progress mb-3" style="height: 25px;">
-                <div class="progress-bar progress-bar-striped progress-bar-animated bg-primary" 
-                     role="progressbar" style="width: 0%" id="bulk-progress-bar">
+              <div class="progress mb-3 h-25">
+                <div class="progress-bar progress-bar-striped progress-bar-animated bg-primary"
+                     role="progressbar" id="bulk-progress-bar">
                   <span id="progress-text">0%</span>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- replace inline style attributes in JS with classes to meet CSP
- add `toast-high` utility class for consistent toast stacking
- set dashboard insight animation delay via dataset and script

## Testing
- `SECRET_KEY=test pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f953b6a94832cbbfd74e96ed192ce