### PR TITLE
Pin email dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,5 +60,5 @@ isort==5.13.2
 pytest==8.3.4
 pytest-django==4.9.0
 pytest-cov==6.0.0
-django-anymail
-resend
+django-anymail==13.0.1
+resend==2.13.0


### PR DESCRIPTION
## Summary
- pin django-anymail and resend with explicit versions

## Testing
- `pytest` *(fails: assert 'upgrade-insecure-requests' in "default-src 'self'; script-src 'self'; object-src 'none'; img-src 'self'; style-src 'self';")*

------
https://chatgpt.com/codex/tasks/task_e_689f9a93e2e0832c959655c0565f8a73