### PR TITLE
Use thread-local logging filter for noisy paths

### DIFF
--- a/core/middleware/log_filter.py
+++ b/core/middleware/log_filter.py
@@ -1,20 +1,38 @@
+"""Request-aware logging suppression middleware."""
 
 import logging
+import threading
+
+
+_thread_local = threading.local()
+
+
+class _NoisyPathFilter(logging.Filter):
+    """Filter that hides low-level logs for noisy endpoints."""
+
+    noisy_paths = ('/transactions/json', '/api/', '/dashboard/kpis')
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - small utility
+        path = getattr(_thread_local, "path", "")
+        if any(p in path for p in self.noisy_paths):
+            return record.levelno >= logging.WARNING
+        return True
+
 
 class SuppressJsonLogMiddleware:
     """Suppress noisy logs for JSON/reporting endpoints."""
-    
+
     def __init__(self, get_response):
         self.get_response = get_response
+        logging.getLogger("django.server").addFilter(_NoisyPathFilter())
 
     def __call__(self, request):
-        noisy_paths = ('/transactions/json', '/api/', '/dashboard/kpis')
-        if any(p in request.path for p in noisy_paths):
-            logger = logging.getLogger('django.server')
-            old = logger.level
-            logger.setLevel(logging.WARNING)
+        _thread_local.path = request.path
+        try:
+            return self.get_response(request)
+        finally:
             try:
-                return self.get_response(request)
-            finally:
-                logger.setLevel(old)
-        return self.get_response(request)
+                del _thread_local.path
+            except AttributeError:  # pragma: no cover - safety
+                pass
+


### PR DESCRIPTION
## Summary
- Replace level toggling in log suppression middleware with a thread-local logging filter
- Avoid global logger changes while filtering noisy endpoint logs

## Testing
- `pytest` *(fails: assert 'upgrade-insecure-requests' in "default-src 'none'; script-src 'self'")*

------
https://chatgpt.com/codex/tasks/task_e_689f9a963690832c93b9ff0a80d7cc0b