### PR TITLE
Refactor transaction list JS to avoid inline styles

### DIFF
--- a/core/static/css/transaction_list_v2.css
+++ b/core/static/css/transaction_list_v2.css
@@ -1,0 +1,3 @@
+/* Styles extracted from inline usage in transaction_list_v2.js */
+.is-hidden { display: none !important; }
+.text-ellipsis { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -182,6 +182,9 @@
             color: #24282C !important;
         }
     </style>
+    <script nonce="{{ request.csp_nonce }}">
+      window.CSP_NONCE = "{{ request.csp_nonce }}";
+    </script>
 </head>
 <body class="bg-light">
 

--- a/core/templates/core/transaction_list_v2.html
+++ b/core/templates/core/transaction_list_v2.html
@@ -1,7 +1,15 @@
 {% extends "base.html" %}
 {% load static %}
 {% load filtros %}
-{% now "Y-m-d" as today %} {% block content %} {% csrf_token %}
+{% now "Y-m-d" as today %}
+
+{% block extra_head %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'css/transaction_list_v2.css' %}">
+{% endblock %}
+
+{% block content %}
+{% csrf_token %}
 <div class="container-fluid mt-4">
   <!-- CSRF Token -->
   <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
@@ -309,7 +317,7 @@
               <th class="th-checkbox">
                 <input
                   type="checkbox"
-                  class="form-check-input d-none"
+                  class="form-check-input is-hidden"
                   id="select-all"
                 />
                 <span class="badge bg-secondary fs-7">#</span>


### PR DESCRIPTION
## Summary
- add nonce-aware DynamicCSS helper and inline style checker
- replace jQuery style mutations with CSS classes in transaction list
- expose CSP nonce and dedicated stylesheet for transaction page

## Testing
- `rg '.css(' core/static/js/transaction_list_v2.js`
- `rg attr('style' core/static/js/transaction_list_v2.js`
- `rg style. core/static/js/transaction_list_v2.js`
- `python -m pytest` *(fails: assert 'upgrade-insecure-requests' in CSP headers)*

------
https://chatgpt.com/codex/tasks/task_e_689f9afe67e0832cb283345a7af52e06