### PR TITLE
Refactor CSP settings for django-csp 4

### DIFF
--- a/ourfinancetracker_site/settings_test.py
+++ b/ourfinancetracker_site/settings_test.py
@@ -36,8 +36,7 @@ AXES_LOCKOUT_HTTP_RESPONSE_CODE = 200
 AXES_HTTP_RESPONSE_CODE = 200
 
 # Ensure CSP middleware emits the upgrade directive during tests
-CSP_UPGRADE_INSECURE_REQUESTS = True
-CSP_REPORT_ONLY = False
+CONTENT_SECURITY_POLICY["DIRECTIVES"]["upgrade-insecure-requests"] = []
 
 # Allow Django test client host
 ALLOWED_HOSTS.append("testserver")

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-redis==5.4.0
 # Security and authentication
 django-axes==6.5.1
 django-ratelimit==4.1.0
-django-csp==3.8
+django-csp==4.0
 argon2-cffi==23.1.0
 PyJWT==2.10.1
 


### PR DESCRIPTION
## Summary
- migrate CSP configuration to new `CONTENT_SECURITY_POLICY` dictionary with nonce support
- ensure tests include `upgrade-insecure-requests` directive
- bump `django-csp` to 4.0

## Testing
- `python manage.py check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fa31e5a90832ca5de57e4473a3e91