### PR TITLE
Fix returns chart visibility

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -1009,7 +1009,7 @@ Dashboard{% endblock %} {% block extra_head %}
         </div>
         <div class="card-body chart-container">
           <canvas id="evolution-chart"></canvas>
-          <canvas id="returns-chart" class="d-none"></canvas>
+          <canvas id="returns-chart"></canvas>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Remove Bootstrap `d-none` class from returns chart canvas so Chart.js can toggle visibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fa6d7faa0832c9f8307b7f7d1391b