### PR TITLE
Fix chart filter persistence when switching views

### DIFF
--- a/core/static/js/dashboard.js
+++ b/core/static/js/dashboard.js
@@ -1621,14 +1621,14 @@ document.addEventListener("DOMContentLoaded", () => {
       evolutionCanvas.style.display = 'block';
     } else if (chartType === 'flows' && flowsCanvas) {
       flowsCanvas.style.display = 'block';
-      updateFlowsChart(analysisData);
     } else if (chartType === 'returns' && returnsCanvas) {
       returnsCanvas.style.display = 'block';
-      updateReturnsChart();
     } else if (chartType === 'expenses' && expensesCanvas) {
       expensesCanvas.style.display = 'block';
-      updateExpensesChart();
     }
+
+    // Ensure the selected chart reflects current filters
+    updateDashboard();
   };
 
   const generateInsights = (data) => {


### PR DESCRIPTION
## Summary
- update chart switch logic to reapply current dashboard filters

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fabba2f34832c8cec2373e75421eb