### PR TITLE
Enforce user scoping on transaction deletion endpoint

### DIFF
--- a/core/services/query_scope.py
+++ b/core/services/query_scope.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import Callable, Type
+
+from django.core.exceptions import PermissionDenied
+from django.db.models import Model, QuerySet
+from django.http import HttpResponseForbidden
+
+
+def scope_queryset(queryset: QuerySet, user) -> QuerySet:
+    """Filter any queryset by the given user."""
+    return queryset.filter(user=user)
+
+
+def get_object_for_user(model: Type[Model], user, **filters):
+    """Return a single model instance scoped to ``user``.
+
+    Raises ``PermissionDenied`` if no object matches the provided filters for the
+    given user.
+    """
+    try:
+        return model.objects.get(user=user, **filters)
+    except model.DoesNotExist as exc:  # type: ignore[attr-defined]
+        raise PermissionDenied from exc
+
+
+def user_scoped(model: Type[Model], lookup_kwarg: str = "pk", obj_kwarg: str = "scoped_obj"):
+    """Decorator ensuring the looked up object belongs to ``request.user``.
+
+    The resolved object is injected into ``kwargs`` using ``obj_kwarg``. If the
+    object does not exist for the authenticated user a ``403`` is returned.
+    """
+
+    def decorator(view_func: Callable):
+        @wraps(view_func)
+        def _wrapped(request, *args, **kwargs):
+            lookup_val = kwargs.get(lookup_kwarg)
+            try:
+                obj = get_object_for_user(model, request.user, id=lookup_val)
+            except PermissionDenied:
+                return HttpResponseForbidden()
+            kwargs[obj_kwarg] = obj
+            return view_func(request, *args, **kwargs)
+
+        return _wrapped
+
+    return decorator

--- a/core/tests/test_user_scope.py
+++ b/core/tests/test_user_scope.py
@@ -1,0 +1,40 @@
+import json
+from decimal import Decimal
+from datetime import date
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+from django.test import Client
+
+from core.models import Transaction
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("acting_user,expected_status", [
+    ("owner", 200),
+    ("other", 403),
+])
+def test_delete_estimated_transaction_scoped(acting_user, expected_status):
+    owner = User.objects.create_user(username="owner", password="p")
+    other = User.objects.create_user(username="other", password="p")
+    tx = Transaction.objects.create(
+        user=owner,
+        amount=Decimal("1"),
+        type=Transaction.Type.EXPENSE,
+        date=date.today(),
+        is_estimated=True,
+    )
+
+    client = Client()
+    if acting_user == "owner":
+        client.force_login(owner)
+    else:
+        client.force_login(other)
+
+    url = reverse("delete_estimated_transaction", args=[tx.id])
+    response = client.post(url)
+    assert response.status_code == expected_status
+    if expected_status == 200:
+        data = json.loads(response.content)
+        assert data["success"] is True


### PR DESCRIPTION
## Summary
- centralize user scoping helpers in `query_scope` service
- apply new decorator to estimated transaction deletion endpoint to enforce ownership
- add regression tests ensuring cross-user access returns 403

## Testing
- `pytest core/tests/test_user_scope.py core/tests/test_returns_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fb078b4c0832c9fd0b82db5390855