### PR TITLE
Normalize KPI styles and add dashboard snapshot

### DIFF
--- a/core/static/css/main.css
+++ b/core/static/css/main.css
@@ -774,17 +774,17 @@ button:hover,
     padding: 0.75rem;
   }
 
-  .kpi-card h6 {
+  .kpi-title {
     font-size: 0.8rem;
     margin-bottom: 0.5rem;
   }
 
-  .kpi-card h4 {
+  .kpi-value {
     font-size: 1.2rem;
     margin-bottom: 0.25rem;
   }
 
-  .kpi-card .progress {
+  .kpi-progress {
     height: 3px;
     margin-top: 0.5rem;
   }
@@ -1004,7 +1004,7 @@ button:hover,
 
 /* ===== Landscape orientation ===== */
 @media (max-width: 768px) and (orientation: landscape) {
-  .kpi-card h4 {
+  .kpi-value {
     font-size: 1rem;
   }
 
@@ -1166,14 +1166,18 @@ button:hover,
   font-family: 'Segoe UI', system-ui, -apple-system, 'Arial', sans-serif;
 }
 
-.kpi-card h6,
-.kpi-card h4,
-.kpi-card small {
+.kpi-title,
+.kpi-value,
+.kpi-subtitle {
   color: inherit !important;
 }
 
-.kpi-card .progress { height: 4px; }
+.kpi-title { margin-bottom: 0.5rem; }
+.kpi-value { margin-bottom: 0.25rem; }
+.kpi-progress { height: 4px; margin-top: 0.5rem; }
 .kpi-card .badge { font-size: .7rem; }
+.kpi-footer { font-size: .7rem; display: block; }
+.kpi-subtitle { font-size: 0.8rem; }
 
 /* Styles migrated from inline attributes */
 .kpi-muted { margin-top: 1rem; color: #666; }

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -78,9 +78,9 @@ Dashboard{% endblock %} {% block extra_head %}
         <div class="card-body">
           <div class="d-flex align-items-center">
             <div class="flex-grow-1">
-              <h6 class="card-title text-muted mb-1">⬆️ Income</h6>
-              <h4 class="mb-0 fw-bold text-success">€ {{ kpis.income|floatformat:2 }}</h4>
-              <small class="text-muted">
+              <h6 class="card-title kpi-title text-muted mb-1">⬆️ Income</h6>
+              <h4 class="kpi-value mb-0 fw-bold text-success">€ {{ kpis.income|floatformat:2 }}</h4>
+              <small class="text-muted kpi-footer">
                 {% if kpis.income > 0 %}
                 <span class="text-success">
                   <i class="fas fa-arrow-up"></i> Active
@@ -100,9 +100,9 @@ Dashboard{% endblock %} {% block extra_head %}
         <div class="card-body">
           <div class="d-flex align-items-center">
             <div class="flex-grow-1">
-              <h6 class="card-title text-muted mb-1">⬇️ Expenses</h6>
-              <h4 class="mb-0 fw-bold text-danger">€ {{ kpis.expenses|floatformat:2 }}</h4>
-              <small class="text-muted">
+              <h6 class="card-title kpi-title text-muted mb-1">⬇️ Expenses</h6>
+              <h4 class="kpi-value mb-0 fw-bold text-danger">€ {{ kpis.expenses|floatformat:2 }}</h4>
+              <small class="text-muted kpi-footer">
                 {% if kpis.income > 0 %}
                 {% widthratio kpis.expenses kpis.income 100 as expense_ratio %}
                 <span class="{% if expense_ratio < 70 %}text-success{% elif expense_ratio < 90 %}text-warning{% else %}text-danger{% endif %}">
@@ -123,9 +123,9 @@ Dashboard{% endblock %} {% block extra_head %}
         <div class="card-body">
           <div class="d-flex align-items-center">
             <div class="flex-grow-1">
-              <h6 class="card-title text-muted mb-1">📈 Investments</h6>
-              <h4 class="mb-0 fw-bold text-primary">€ {{ kpis.investments|floatformat:2 }}</h4>
-              <small class="text-muted">
+              <h6 class="card-title kpi-title text-muted mb-1">📈 Investments</h6>
+              <h4 class="kpi-value mb-0 fw-bold text-primary">€ {{ kpis.investments|floatformat:2 }}</h4>
+              <small class="text-muted kpi-footer">
                 {% if kpis.income > 0 %}
                 {% widthratio kpis.investments kpis.income 100 as investment_ratio %}
                 <span class="{% if investment_ratio > 20 %}text-success{% elif investment_ratio > 10 %}text-warning{% else %}text-muted{% endif %}">
@@ -146,9 +146,9 @@ Dashboard{% endblock %} {% block extra_head %}
         <div class="card-body">
           <div class="d-flex align-items-center">
             <div class="flex-grow-1">
-              <h6 class="card-title text-muted mb-1">⚖️ Net Balance</h6>
-              <h4 class="mb-0 fw-bold text-{% if kpis.net >= 0 %}success{% else %}danger{% endif %}">€ {{ kpis.net|floatformat:2 }}</h4>
-              <small class="text-muted">
+              <h6 class="card-title kpi-title text-muted mb-1">⚖️ Net Balance</h6>
+              <h4 class="kpi-value mb-0 fw-bold text-{% if kpis.net >= 0 %}success{% else %}danger{% endif %}">€ {{ kpis.net|floatformat:2 }}</h4>
+              <small class="text-muted kpi-footer">
                 {% if kpis.net >= 0 %}
                 <span class="text-success">
                   <i class="fas fa-check-circle"></i> Positive flow
@@ -867,19 +867,19 @@ Dashboard{% endblock %} {% block extra_head %}
         <div class="card-body text-center p-3">
           <div class="d-flex justify-content-between align-items-center">
             <div>
-              <h6 class="card-title text-success mb-1">⬆️ Average Income</h6>
-              <h4 class="card-text mb-0" id="receita-media">€ 0</h4>
-              <small class="text-muted">Monthly</small>
+              <h6 class="card-title kpi-title text-success mb-1">⬆️ Average Income</h6>
+              <h4 class="card-text kpi-value mb-0" id="receita-media">€ 0</h4>
+              <small class="text-muted kpi-subtitle">Monthly</small>
             </div>
             <i class="fas fa-arrow-up fa-2x text-success opacity-25"></i>
           </div>
-          <div class="progress mt-2 progress-xthin">
+          <div class="progress kpi-progress mt-2 progress-xthin">
             <div
               class="progress-bar bg-success w-0"
               id="receita-progress"
             ></div>
           </div>
-          <small class="text-muted mt-1 d-block" id="receita-change">-</small>
+          <small class="text-muted kpi-footer" id="receita-change">-</small>
         </div>
       </div>
     </div>
@@ -888,19 +888,19 @@ Dashboard{% endblock %} {% block extra_head %}
         <div class="card-body text-center p-3">
           <div class="d-flex justify-content-between align-items-center">
             <div>
-              <h6 class="card-title text-danger mb-1">⬇️ Expenses</h6>
-              <h4 class="card-text mb-0" id="despesa-estimada">€ 0</h4>
-              <small class="text-muted">Calculated</small>
+              <h6 class="card-title kpi-title text-danger mb-1">⬇️ Expenses</h6>
+              <h4 class="card-text kpi-value mb-0" id="despesa-estimada">€ 0</h4>
+              <small class="text-muted kpi-subtitle">Calculated</small>
             </div>
             <i class="fas fa-arrow-down fa-2x text-danger opacity-25"></i>
           </div>
-          <div class="progress mt-2 progress-xthin">
+          <div class="progress kpi-progress mt-2 progress-xthin">
             <div
               class="progress-bar bg-danger w-0"
               id="despesa-progress"
             ></div>
           </div>
-          <small class="text-muted mt-1 d-block" id="despesa-change">-</small>
+          <small class="text-muted kpi-footer" id="despesa-change">-</small>
         </div>
       </div>
     </div>
@@ -908,7 +908,7 @@ Dashboard{% endblock %} {% block extra_head %}
     <div class="col-xl-2 col-lg-4 col-md-6 col-sm-6 mb-3">
       {% with verified=kpis.verified_expenses_pct|clamp_pct verification=kpis.verification_level|default:"Moderate" verified_str=kpis.verified_expenses_pct|clamp_pct|floatformat:2 %}
         {% with aria="Verified Expenses, "|add:verified_str|add:" percent. Verification: "|add:verification %}
-          {% include "core/partials/kpi_card.html" with border_class="border-info" title_class="text-info" title="Verified Expenses" icon='<i class="fas fa-receipt fa-2x text-info opacity-25"></i>' value_id="verified-expenses" value=verified_str|add:"%" subtitle="Share of total expenses" meter=verified progress_id="verified-progress" progress_bar_class="bg-info" footer_id="verified-change" footer="Verification: "|add:verification footer_badge_class="badge bg-warning-subtle text-warning-emphasis" info_tooltip="Share of total expenses that are verified (not estimated)." aria_label=aria %}
+          {% include "core/partials/kpi_card.html" with border_class="border-info" title_class="text-info" title="Verified Expenses" icon='<i class="fas fa-receipt fa-2x text-info opacity-25"></i>' value_id="verified-expenses" value=verified_str|add:"%" subtitle="Share of total expenses" progress_id="verified-progress" progress_bar_class="bg-info" footer_id="verified-change" footer="Verification: "|add:verification footer_badge_class="badge bg-warning-subtle text-warning-emphasis" info_tooltip="Share of total expenses that are verified (not estimated)." aria_label=aria %}
         {% endwith %}
       {% endwith %}
     </div>
@@ -917,19 +917,19 @@ Dashboard{% endblock %} {% block extra_head %}
         <div class="card-body text-center p-3">
           <div class="d-flex justify-content-between align-items-center">
             <div>
-              <h6 class="card-title text-info mb-1">📈 Invested Amount</h6>
-              <h4 class="card-text mb-0" id="valor-investido">€ 0</h4>
-              <small class="text-muted">Total</small>
+              <h6 class="card-title kpi-title text-info mb-1">📈 Invested Amount</h6>
+              <h4 class="card-text kpi-value mb-0" id="valor-investido">€ 0</h4>
+              <small class="text-muted kpi-subtitle">Total</small>
             </div>
             <i class="fas fa-chart-line fa-2x text-info opacity-25"></i>
           </div>
-          <div class="progress mt-2 progress-xthin">
+          <div class="progress kpi-progress mt-2 progress-xthin">
             <div
               class="progress-bar bg-info w-0"
               id="investido-progress"
             ></div>
           </div>
-          <small class="text-muted mt-1 d-block" id="investido-change">-</small>
+          <small class="text-muted kpi-footer" id="investido-change">-</small>
         </div>
       </div>
     </div>
@@ -938,21 +938,19 @@ Dashboard{% endblock %} {% block extra_head %}
         <div class="card-body text-center p-3">
           <div class="d-flex justify-content-between align-items-center">
             <div>
-              <h6 class="card-title text-purple mb-1">⚖️ Total Net Worth</h6>
-              <h4 class="card-text mb-0" id="patrimonio-total">€ 0</h4>
-              <small class="text-muted">Current</small>
+              <h6 class="card-title kpi-title text-purple mb-1">⚖️ Total Net Worth</h6>
+              <h4 class="card-text kpi-value mb-0" id="patrimonio-total">€ 0</h4>
+              <small class="text-muted kpi-subtitle">Current</small>
             </div>
             <i class="fas fa-gem fa-2x text-purple opacity-25"></i>
           </div>
-          <div class="progress mt-2 progress-xthin">
+          <div class="progress kpi-progress mt-2 progress-xthin">
             <div
               class="progress-bar bg-purple w-0"
               id="patrimonio-progress"
             ></div>
           </div>
-          <small class="text-muted mt-1 d-block" id="patrimonio-change"
-            >-</small
-          >
+          <small class="text-muted kpi-footer" id="patrimonio-change">-</small>
         </div>
       </div>
     </div>
@@ -961,19 +959,19 @@ Dashboard{% endblock %} {% block extra_head %}
         <div class="card-body text-center p-3">
           <div class="d-flex justify-content-between align-items-center">
             <div>
-              <h6 class="card-title text-dark mb-1">⚖️ Savings Rate</h6>
-              <h4 class="card-text mb-0" id="taxa-poupanca">0%</h4>
-              <small class="text-muted">of income</small>
+              <h6 class="card-title kpi-title text-dark mb-1">⚖️ Savings Rate</h6>
+              <h4 class="card-text kpi-value mb-0" id="taxa-poupanca">0%</h4>
+              <small class="text-muted kpi-subtitle">of income</small>
             </div>
             <i class="fas fa-percent fa-2x text-dark opacity-25"></i>
           </div>
-          <div class="progress mt-2 progress-xthin">
+          <div class="progress kpi-progress mt-2 progress-xthin">
             <div
               class="progress-bar bg-dark w-0"
               id="poupanca-progress"
             ></div>
           </div>
-          <small class="text-muted mt-1 d-block" id="poupanca-change">-</small>
+          <small class="text-muted kpi-footer" id="poupanca-change">-</small>
         </div>
       </div>
     </div>

--- a/core/templates/core/partials/kpi_card.html
+++ b/core/templates/core/partials/kpi_card.html
@@ -2,24 +2,19 @@
   <div class="card-body text-center p-3">
     <div class="d-flex justify-content-between align-items-center">
       <div>
-        <h6 class="card-title {{ title_class }} mb-1">{{ title }}{% if info_tooltip %}
+        <h6 class="card-title kpi-title {{ title_class }} mb-1">{{ title }}{% if info_tooltip %}
           <i class="fas fa-info-circle ms-1" data-bs-toggle="tooltip" title="{{ info_tooltip }}"></i>
         {% endif %}</h6>
-        <h4 class="card-text mb-0"{% if value_id %} id="{{ value_id }}"{% endif %}>{{ value }}</h4>
-        {% if subtitle %}<small class="text-muted">{{ subtitle }}</small>{% endif %}
+        <h4 class="card-text kpi-value mb-0"{% if value_id %} id="{{ value_id }}"{% endif %}>{{ value }}</h4>
+        {% if subtitle %}<small class="text-muted kpi-subtitle">{{ subtitle }}</small>{% endif %}
       </div>
       {% if icon %}{{ icon|safe }}{% endif %}
     </div>
-    <div class="progress mt-2 progress-xthin">
-      <div class="progress-bar {{ progress_bar_class }}"{% if progress_id %} id="{{ progress_id }}"{% endif %}></div>
+    <div class="progress kpi-progress mt-2 progress-xthin">
+      <div class="progress-bar {{ progress_bar_class }} w-0"{% if progress_id %} id="{{ progress_id }}"{% endif %}></div>
     </div>
-    {% if progress_id %}
-    <style nonce="{{ request.csp_nonce }}">#{{ progress_id }} { width: {{ meter }}%; }</style>
-    {% else %}
-    <style nonce="{{ request.csp_nonce }}">.kpi-progress-bar { width: {{ meter }}%; }</style>
-    {% endif %}
     {% if footer %}
-    <small class="text-muted mt-1 d-block"{% if footer_id %} id="{{ footer_id }}"{% endif %}>
+    <small class="text-muted kpi-footer"{% if footer_id %} id="{{ footer_id }}"{% endif %}>
       {% if footer_badge_class %}<span class="{{ footer_badge_class }}">{{ footer }}</span>{% else %}{{ footer }}{% endif %}
     </small>
     {% endif %}

--- a/core/tests/snapshots/verified_expenses_card.html
+++ b/core/tests/snapshots/verified_expenses_card.html
@@ -1,0 +1,22 @@
+<div class="card border-info h-100 kpi-card" aria-label="Verified Expenses, 0.00 percent. Verification: Moderate">
+  <div class="card-body text-center p-3">
+    <div class="d-flex justify-content-between align-items-center">
+      <div>
+        <h6 class="card-title kpi-title text-info mb-1">Verified Expenses
+          <i class="fas fa-info-circle ms-1" data-bs-toggle="tooltip" title="Share of total expenses that are verified (not estimated)."></i>
+        </h6>
+        <h4 class="card-text kpi-value mb-0" id="verified-expenses">0.00%</h4>
+        <small class="text-muted kpi-subtitle">Share of total expenses</small>
+      </div>
+      <i class="fas fa-receipt fa-2x text-info opacity-25"></i>
+    </div>
+    <div class="progress kpi-progress mt-2 progress-xthin">
+      <div class="progress-bar bg-info w-0" id="verified-progress"></div>
+    </div>
+    
+    <small class="text-muted kpi-footer" id="verified-change">
+      <span class="badge bg-warning-subtle text-warning-emphasis">Verification: Moderate</span>
+    </small>
+    
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Standardize KPI card classes and remove inline styles
- Align dashboard KPI markup with shared component
- Add snapshot test for Verified Expenses card

## Testing
- `DATABASE_URL=sqlite:///:memory: SUPABASE_DB_URL= pytest core/tests/test_dashboard_template.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689fb034b7dc832cb283b0cbb987341d