### PR TITLE
Implement recurring transactions with Celery

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -9,6 +9,7 @@ from .models import (
     Category,
     Transaction,
     UserSettings,
+    RecurringTransaction,
 )
 
 # Registo simples
@@ -28,3 +29,10 @@ class TransactionAdmin(admin.ModelAdmin):
     list_filter = ("type", "user", "is_estimated")
     search_fields = ("notes",)
     autocomplete_fields = ("category",)
+
+
+@admin.register(RecurringTransaction)
+class RecurringTransactionAdmin(admin.ModelAdmin):
+    list_display = ("user", "schedule", "amount", "next_run_at", "active")
+    list_filter = ("schedule", "active")
+    autocomplete_fields = ("category", "account")

--- a/core/forms.py
+++ b/core/forms.py
@@ -23,6 +23,7 @@ from .models import (
     AccountType,
     Currency,
     Tag,
+    RecurringTransaction,
     ALLOWED_ACCOUNT_TYPE_NAMES,
 )
 
@@ -542,3 +543,24 @@ class TransactionImportForm(forms.Form):
             "class": "form-control"
         })
     )
+
+
+class RecurringTransactionForm(UserAwareMixin, forms.ModelForm):
+    class Meta:
+        model = RecurringTransaction
+        fields = ["schedule", "amount", "account", "category", "tags", "next_run_at", "active"]
+        widgets = {
+            "schedule": forms.Select(attrs={"class": "form-select"}),
+            "amount": forms.TextInput(attrs={"class": "form-control text-end"}),
+            "account": forms.Select(attrs={"class": "form-select"}),
+            "category": forms.Select(attrs={"class": "form-select"}),
+            "tags": forms.SelectMultiple(attrs={"class": "form-select"}),
+            "next_run_at": forms.DateTimeInput(attrs={"type": "datetime-local", "class": "form-control"}),
+        }
+
+    def __init__(self, *args, user: User | None = None, **kwargs):
+        super().__init__(*args, user=user, **kwargs)
+        if self.user:
+            self.fields["account"].queryset = Account.objects.filter(user=self.user)
+            self.fields["category"].queryset = Category.objects.filter(user=self.user)
+            self.fields["tags"].queryset = Tag.objects.filter(user=self.user)

--- a/core/migrations/0015_recurring_transaction.py
+++ b/core/migrations/0015_recurring_transaction.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0014_alter_tag_category_alter_transaction_editable_and_more'),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name='RecurringTransaction',
+        ),
+        migrations.CreateModel(
+            name='RecurringTransaction',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('schedule', models.CharField(choices=[('daily', 'Daily'), ('weekly', 'Weekly'), ('monthly', 'Monthly')], max_length=10)),
+                ('amount', models.DecimalField(decimal_places=2, max_digits=14)),
+                ('next_run_at', models.DateTimeField()),
+                ('active', models.BooleanField(default=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('account', models.ForeignKey(blank=True, null=True, on_delete=models.SET_NULL, related_name='recurring_transactions', to='core.account')),
+                ('category', models.ForeignKey(blank=True, null=True, on_delete=models.SET_NULL, related_name='recurring_templates', to='core.category')),
+                ('user', models.ForeignKey(on_delete=models.CASCADE, related_name='recurring_transactions', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='recurringtransaction',
+            name='tags',
+            field=models.ManyToManyField(blank=True, related_name='recurring_transactions', to='core.tag'),
+        ),
+    ]

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -1,0 +1,24 @@
+from django.utils import timezone
+from celery import shared_task
+
+from .models import RecurringTransaction, Transaction
+
+
+@shared_task
+def process_recurring_transactions():
+    """Create transactions for due recurring definitions."""
+    now = timezone.now()
+    qs = RecurringTransaction.objects.filter(active=True, next_run_at__lte=now)
+    for rt in qs.select_related("account", "category").prefetch_related("tags"):
+        tx, created = Transaction.objects.get_or_create(
+            user=rt.user,
+            date=rt.next_run_at.date(),
+            amount=rt.amount,
+            account=rt.account,
+            category=rt.category,
+            notes=f"Recurring {rt.id}",
+            defaults={"type": Transaction.Type.EXPENSE},
+        )
+        if created and rt.tags.exists():
+            tx.tags.set(rt.tags.all())
+        rt.schedule_next()

--- a/core/templates/core/confirms/recurring_confirm_delete.html
+++ b/core/templates/core/confirms/recurring_confirm_delete.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Delete Recurring Transaction?</h1>
+<form method="post">
+  {% csrf_token %}
+  <p>Are you sure you want to delete {{ object }}?</p>
+  <button type="submit" class="btn btn-danger">Confirm</button>
+</form>
+{% endblock %}

--- a/core/templates/core/recurringtransaction_form.html
+++ b/core/templates/core/recurringtransaction_form.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Recurring Transaction</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/core/templates/core/recurringtransaction_list.html
+++ b/core/templates/core/recurringtransaction_list.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Recurring Transactions</h1>
+<table class="table">
+  <tr><th>Schedule</th><th>Amount</th><th>Next run</th><th></th></tr>
+  {% for obj in object_list %}
+  <tr>
+    <td>{{ obj.get_schedule_display }}</td>
+    <td>{{ obj.amount }}</td>
+    <td>{{ obj.next_run_at }}</td>
+    <td>
+      <a href="{% url 'recurring_update' obj.pk %}">Edit</a>
+      <a href="{% url 'recurring_delete' obj.pk %}">Delete</a>
+    </td>
+  </tr>
+  {% empty %}
+  <tr><td colspan="4">No recurring transactions.</td></tr>
+  {% endfor %}
+</table>
+<a href="{% url 'recurring_create' %}">Add new</a>
+{% endblock %}

--- a/core/tests/test_recurring_transactions.py
+++ b/core/tests/test_recurring_transactions.py
@@ -1,0 +1,58 @@
+import pytest
+from django.contrib.auth.models import User
+from django.utils import timezone
+from datetime import timedelta
+from dateutil.relativedelta import relativedelta
+
+from core.models import Category, Account, RecurringTransaction, Transaction, Tag
+from core.tasks import process_recurring_transactions
+
+
+@pytest.mark.django_db
+def test_schedule_next():
+    user = User.objects.create_user("u1")
+    cat = Category.objects.create(user=user, name="Food")
+    acc = Account.objects.create(user=user, name="Wallet")
+    now = timezone.now()
+    rt_daily = RecurringTransaction.objects.create(user=user, schedule="daily", category=cat, account=acc, amount=1, next_run_at=now)
+    rt_weekly = RecurringTransaction.objects.create(user=user, schedule="weekly", category=cat, account=acc, amount=1, next_run_at=now)
+    rt_monthly = RecurringTransaction.objects.create(user=user, schedule="monthly", category=cat, account=acc, amount=1, next_run_at=now)
+    rt_daily.schedule_next()
+    rt_weekly.schedule_next()
+    rt_monthly.schedule_next()
+    assert rt_daily.next_run_at.date() == (now + timedelta(days=1)).date()
+    assert rt_weekly.next_run_at.date() == (now + timedelta(weeks=1)).date()
+    assert rt_monthly.next_run_at.date() == (now + relativedelta(months=1)).date()
+
+
+@pytest.mark.django_db
+def test_task_creates_transaction_and_reschedules():
+    user = User.objects.create_user("u2")
+    cat = Category.objects.create(user=user, name="Bills")
+    acc = Account.objects.create(user=user, name="Checking")
+    tag = Tag.objects.create(user=user, name="Auto")
+    past = timezone.now() - timedelta(days=1)
+    rt = RecurringTransaction.objects.create(user=user, schedule="daily", category=cat, account=acc, amount=10, next_run_at=past)
+    rt.tags.add(tag)
+    process_recurring_transactions()
+    tx = Transaction.objects.get(user=user, notes=f"Recurring {rt.id}")
+    assert tx.amount == 10
+    assert tag in tx.tags.all()
+    rt.refresh_from_db()
+    assert rt.next_run_at.date() == (past + timedelta(days=1)).date()
+
+
+@pytest.mark.django_db
+def test_task_idempotent():
+    user = User.objects.create_user("u3")
+    cat = Category.objects.create(user=user, name="Rent")
+    acc = Account.objects.create(user=user, name="Bank")
+    past = timezone.now() - timedelta(days=1)
+    rt = RecurringTransaction.objects.create(user=user, schedule="daily", category=cat, account=acc, amount=20, next_run_at=past)
+    process_recurring_transactions()
+    # reset to simulate second run for same schedule
+    rt.next_run_at = past
+    rt.save(update_fields=["next_run_at"])
+    process_recurring_transactions()
+    count = Transaction.objects.filter(user=user, notes=f"Recurring {rt.id}").count()
+    assert count == 1

--- a/core/urls.py
+++ b/core/urls.py
@@ -8,6 +8,10 @@ from .views import (
     # Transactions
     TransactionCreateView,
     TransactionUpdateView, TransactionDeleteView,
+    RecurringTransactionListView,
+    RecurringTransactionCreateView,
+    RecurringTransactionUpdateView,
+    RecurringTransactionDeleteView,
     transactions_json, import_transactions_xlsx,
     import_transactions_template, transaction_clear_cache,
     export_transactions_xlsx, export_data_xlsx, transaction_bulk_update,
@@ -85,6 +89,12 @@ urlpatterns = [
     path('transactions/estimate/years/', views.get_available_years, name='get_available_years'),
     path('transactions/estimate/<int:transaction_id>/delete/', views.delete_estimated_transaction, name='delete_estimated_transaction'),
     path('transactions/estimate/period/<int:period_id>/delete/', views.delete_estimated_transaction_by_period, name='delete_estimated_transaction_by_period'),
+
+    # Recurring transactions
+    path("recurring/", RecurringTransactionListView.as_view(), name="recurring_list"),
+    path("recurring/new/", RecurringTransactionCreateView.as_view(), name="recurring_create"),
+    path("recurring/<int:pk>/edit/", RecurringTransactionUpdateView.as_view(), name="recurring_update"),
+    path("recurring/<int:pk>/delete/", RecurringTransactionDeleteView.as_view(), name="recurring_delete"),
 
     # Categories
     path("categories/", CategoryListView.as_view(), name="category_list"),

--- a/core/views.py
+++ b/core/views.py
@@ -61,6 +61,7 @@ from .forms import (
     CategoryForm,
     TransactionForm,
     UserInFormKwargsMixin,
+    RecurringTransactionForm,
 )
 from .models import (
     Account,
@@ -72,6 +73,7 @@ from .models import (
     Tag,
     Transaction,
     User,
+    RecurringTransaction,
 )
 from .utils.cache_helpers import clear_tx_cache
 
@@ -715,6 +717,44 @@ class TransactionDeleteView(OwnerQuerysetMixin, DeleteView):
 
         # For regular requests, use standard flow
         return super().post(request, *args, **kwargs)
+
+
+class RecurringTransactionListView(LoginRequiredMixin, ListView):
+    model = RecurringTransaction
+    template_name = "core/recurringtransaction_list.html"
+
+    def get_queryset(self):
+        return RecurringTransaction.objects.filter(user=self.request.user)
+
+
+class RecurringTransactionCreateView(LoginRequiredMixin, UserInFormKwargsMixin, CreateView):
+    model = RecurringTransaction
+    form_class = RecurringTransactionForm
+    template_name = "core/recurringtransaction_form.html"
+    success_url = reverse_lazy("recurring_list")
+
+    def form_valid(self, form):
+        form.instance.user = self.request.user
+        return super().form_valid(form)
+
+
+class RecurringTransactionUpdateView(OwnerQuerysetMixin, UserInFormKwargsMixin, UpdateView):
+    model = RecurringTransaction
+    form_class = RecurringTransactionForm
+    template_name = "core/recurringtransaction_form.html"
+    success_url = reverse_lazy("recurring_list")
+
+    def get_queryset(self):
+        return RecurringTransaction.objects.filter(user=self.request.user)
+
+
+class RecurringTransactionDeleteView(OwnerQuerysetMixin, DeleteView):
+    model = RecurringTransaction
+    template_name = "core/confirms/recurring_confirm_delete.html"
+    success_url = reverse_lazy("recurring_list")
+
+    def get_queryset(self):
+        return RecurringTransaction.objects.filter(user=self.request.user)
 
 
 

--- a/ourfinancetracker_site/__init__.py
+++ b/ourfinancetracker_site/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/ourfinancetracker_site/celery.py
+++ b/ourfinancetracker_site/celery.py
@@ -1,0 +1,13 @@
+import os
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ourfinancetracker_site.settings")
+
+app = Celery("ourfinancetracker")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print(f"Request: {self.request!r}")

--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -101,6 +101,7 @@ INSTALLED_APPS = [
     "csp",
     "axes",
     "anymail",
+    "django_celery_beat",
     # Projeto
     "accounts",
     "core",
@@ -365,6 +366,13 @@ LOGGING = {
 SUPABASE_URL = ENV("SUPABASE_URL")
 SUPABASE_KEY = ENV("SUPABASE_KEY")
 SUPABASE_JWT_SECRET = ENV("SUPABASE_JWT_SECRET")
+
+# Celery
+CELERY_BROKER_URL = ENV("CELERY_BROKER_URL", default="memory://")
+CELERY_RESULT_BACKEND = ENV("CELERY_RESULT_BACKEND", default="cache+memory://")
+CELERY_ACCEPT_CONTENT = ["json"]
+CELERY_TASK_SERIALIZER = "json"
+CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
 # --- Final dev overrides (must stay at the end of settings.py) ---
 if DEBUG:

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,10 @@ xlsxwriter==3.2.0
 # Date processing
 python-dateutil==2.9.0.post0
 
+# Task queue
+celery==5.3.6
+django-celery-beat==2.6.0
+
 # Development and debug
 django-debug-toolbar==4.4.6
 


### PR DESCRIPTION
## Summary
- add `RecurringTransaction` model with schedule and template fields
- integrate Celery/Beat to materialize due recurring transactions
- add forms, views, and tests for recurring transactions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fb0454e24832cb553cadde41ef1df