### PR TITLE
Add CSP nonce to all script tags

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -371,11 +371,11 @@
   </div>
 </div>
 
-<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
-<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js" defer></script>
-<script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js" defer></script>
-<script src="{% static 'js/main.js' %}" defer></script>
+<script src="https://code.jquery.com/jquery-3.7.1.min.js" nonce="{{ request.csp_nonce }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer nonce="{{ request.csp_nonce }}"></script>
+<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js" defer nonce="{{ request.csp_nonce }}"></script>
+<script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js" defer nonce="{{ request.csp_nonce }}"></script>
+<script src="{% static 'js/main.js' %}" defer nonce="{{ request.csp_nonce }}"></script>
 
 <script nonce="{{ request.csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {

--- a/core/templates/core/account_balance.html
+++ b/core/templates/core/account_balance.html
@@ -212,7 +212,7 @@
 </div>
 
 <!-- JS -->
-<script src="{% static 'js/account_balance.js' %}" defer></script>
-<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-<script src="{% static 'js/drag_reorder.js' %}" defer></script>
+<script src="{% static 'js/account_balance.js' %}" defer nonce="{{ request.csp_nonce }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js" nonce="{{ request.csp_nonce }}"></script>
+<script src="{% static 'js/drag_reorder.js' %}" defer nonce="{{ request.csp_nonce }}"></script>
 {% endblock %}

--- a/core/templates/core/account_list.html
+++ b/core/templates/core/account_list.html
@@ -175,7 +175,7 @@
 </div>
 
 <!-- JS: Sortable + Reorder script -->
-<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-<script src="{% static 'js/drag_reorder.js' %}" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js" nonce="{{ request.csp_nonce }}"></script>
+<script src="{% static 'js/drag_reorder.js' %}" defer nonce="{{ request.csp_nonce }}"></script>
 
 {% endblock %}

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -1083,14 +1083,14 @@ Dashboard{% endblock %} {% block extra_head %}
 
 {% endblock %} {% block extra_js %}
 <!-- Chart.js with advanced plugins -->
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js" nonce="{{ request.csp_nonce }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js" nonce="{{ request.csp_nonce }}"></script>
 <!-- noUiSlider for range filters -->
 <link
   href="https://cdn.jsdelivr.net/npm/nouislider@15.7.0/dist/nouislider.min.css"
   rel="stylesheet"
 />
-<script src="https://cdn.jsdelivr.net/npm/nouislider@15.7.0/dist/nouislider.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/nouislider@15.7.0/dist/nouislider.min.js" nonce="{{ request.csp_nonce }}"></script>
 
 <style nonce="{{ request.csp_nonce }}">
   .card {
@@ -1502,5 +1502,5 @@ Dashboard{% endblock %} {% block extra_head %}
     window.location.href = `/dashboard/?mode=period&period=${encodeURIComponent(this.value)}`;
   });
 </script>
-<script type="module" src="{% static 'js/dashboard.js' %}"></script>
+<script type="module" src="{% static 'js/dashboard.js' %}" nonce="{{ request.csp_nonce }}"></script>
 {% endblock %}

--- a/core/templates/core/estimate_transactions.html
+++ b/core/templates/core/estimate_transactions.html
@@ -363,5 +363,5 @@
     // Ensure jQuery is loaded and pass CSRF token to the EstimationManager
     window.csrfToken = '{{ csrf_token }}';
 </script>
-<script src="{% static 'js/estimate_transactions.js' %}" defer></script>
+<script src="{% static 'js/estimate_transactions.js' %}" defer nonce="{{ request.csp_nonce }}"></script>
 {% endblock %}

--- a/core/templates/core/import_balances_form.html
+++ b/core/templates/core/import_balances_form.html
@@ -115,5 +115,5 @@
 </div>
 
 <!-- Bootstrap JS (for alerts) -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer nonce="{{ request.csp_nonce }}"></script>
 {% endblock %}

--- a/core/templates/core/import_form.html
+++ b/core/templates/core/import_form.html
@@ -84,7 +84,7 @@
 </div>
 
 <!-- Bootstrap JS (para alertas e botão fechar) -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer nonce="{{ request.csp_nonce }}"></script>
 
 <script nonce="{{ request.csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {

--- a/core/templates/core/transaction_form.html
+++ b/core/templates/core/transaction_form.html
@@ -146,7 +146,7 @@
 <!-- Flatpickr + Tom Select -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tom-select/dist/css/tom-select.css">
-<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-<script src="https://cdn.jsdelivr.net/npm/tom-select/dist/js/tom-select.complete.min.js"></script>
-<script src="{% static 'js/transaction_form.js' %}"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr" nonce="{{ request.csp_nonce }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/tom-select/dist/js/tom-select.complete.min.js" nonce="{{ request.csp_nonce }}"></script>
+<script src="{% static 'js/transaction_form.js' %}" nonce="{{ request.csp_nonce }}"></script>
 {% endblock %}

--- a/core/templates/core/transaction_list_v2.html
+++ b/core/templates/core/transaction_list_v2.html
@@ -441,8 +441,8 @@
 </script>
 
 <!-- Page-specific dependencies -->
-<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr" nonce="{{ request.csp_nonce }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js" nonce="{{ request.csp_nonce }}"></script>
 <link
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css"
@@ -939,6 +939,6 @@
 </style>
 
 <!-- Custom JavaScript -->
-<script src="{% static 'js/transaction_list_ajax.js' %}"></script>
+<script src="{% static 'js/transaction_list_ajax.js' %}" nonce="{{ request.csp_nonce }}"></script>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure every script tag supplies the request CSP nonce
- keep global `window.CSP_NONCE` definition for dynamic use

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fc4a0b3b8832ca95b76b5174ebdca