### PR TITLE
Fix redirect helper to resolve named URLs correctly

### DIFF
--- a/core/tests/test_home_view.py
+++ b/core/tests/test_home_view.py
@@ -17,4 +17,4 @@ def test_home_view_redirects_authenticated_user(client, settings):
     client.force_login(user)
     response = client.get(reverse("home"))
     assert response.status_code == 302
-    assert response.url.rstrip("/") == reverse("dashboard").strip("/")
+    assert response.url == reverse("dashboard")

--- a/core/views.py
+++ b/core/views.py
@@ -38,10 +38,9 @@ from django.http import (
     Http404,
     HttpResponse,
     HttpResponseForbidden,
-    HttpResponseRedirect as redirect,
     JsonResponse,
 )
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, render, redirect
 from django.urls import reverse, reverse_lazy
 from django.utils.timezone import now
 from django.views import View


### PR DESCRIPTION
## Summary
- fix redirect import to use django.shortcuts.redirect
- tighten home view test to verify full redirect URL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fcbd45db4832c81c6df2c8f47d411