### PR TITLE
Run tests before pushing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: pytest
+        name: Run pytest
+        entry: pytest
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/README.md
+++ b/README.md
@@ -102,3 +102,14 @@ Distributed under the MIT licence. See the `LICENSE` file for more details.
 ```bash
 DATABASE_URL=sqlite:////tmp/testdb.sqlite3 pytest
 ```
+
+To ensure the test suite passes before code is pushed, install the
+`pre-commit` hook that runs tests on the `pre-push` stage:
+
+```bash
+pip install pre-commit
+pre-commit install --hook-type pre-push
+```
+
+With the hook installed, `pytest` is executed automatically and the push is
+blocked if any test fails.


### PR DESCRIPTION
## Summary
- add pre-push pre-commit hook to run pytest before pushing
- document pre-commit test hook usage in README

## Testing
- `pre-commit run --hook-stage pre-push --files README.md .pre-commit-config.yaml`
- `DATABASE_URL=sqlite:////tmp/testdb.sqlite3 pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fce0d9c50832ca2f751d897f8031d