### PR TITLE
Add comprehensive tests for models, forms, imports, cache, and security

### DIFF
--- a/core/tests/test_cache_helpers.py
+++ b/core/tests/test_cache_helpers.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from django.core.cache import cache
+from core.utils.cache_helpers import clear_tx_cache, get_cache_key_for_transactions
+from datetime import date
+
+
+@pytest.mark.django_db
+def test_clear_tx_cache_removes_keys():
+    key = get_cache_key_for_transactions(1, date.today().replace(day=1), date.today())
+    cache.set(key, 'value')
+    clear_tx_cache(1, force=True)
+    assert cache.get(key) is None
+
+
+def test_clear_tx_cache_handles_missing_keys():
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+    mock_cache.delete.side_effect = KeyError
+    with patch('core.utils.cache_helpers.cache', mock_cache):
+        clear_tx_cache(2, force=True)
+    assert mock_cache.delete.call_count > 0

--- a/core/tests/test_csp_headers.py
+++ b/core/tests/test_csp_headers.py
@@ -47,3 +47,10 @@ class TestCSPHeaders(SimpleTestCase):
         # Heuristic: count occurrences of 'default-src' or the final semicolon blocks
         assert csp.count("default-src") == 1, f"CSP appears duplicated: {csp}"
 
+
+    def test_csp_header_contains_script_src(self):
+        url = self._get_ok_url()
+        resp = self.client.get(url)
+        csp = resp.headers.get("Content-Security-Policy")
+        assert csp
+        assert "script-src" in csp

--- a/core/tests/test_email_helpers.py
+++ b/core/tests/test_email_helpers.py
@@ -1,10 +1,11 @@
-import smtplib
 from unittest.mock import patch
-
+import smtplib
 import pytest
 from django.contrib.auth.models import User
 from django.test import RequestFactory
+from django.core import mail
 from django.core.mail import BadHeaderError
+from django.urls import reverse
 
 from core.utils.email_helpers import (
     send_account_activation_email,
@@ -39,3 +40,37 @@ def test_send_account_activation_email_failure():
             ):
                 success = send_account_activation_email(user, request)
     assert not success
+
+
+@pytest.mark.django_db
+def test_send_account_activation_email_success():
+    user = User.objects.create_user(username="alice", email="alice@example.com", password="x")
+    request = RequestFactory().get("/")
+    assert send_account_activation_email(user, request)
+    assert len(mail.outbox) == 1
+    email = mail.outbox[0]
+    assert email.subject == "Activate your account"
+    assert email.to == ["alice@example.com"]
+    assert "activate" in email.body.lower()
+
+
+@pytest.mark.django_db
+def test_password_reset_email(client):
+    user = User.objects.create_user(username="bob", email="bob@example.com", password="secret")
+    response = client.post(reverse('accounts:password_reset'), {"email": "bob@example.com"})
+    assert response.status_code in (302, 200)
+    assert len(mail.outbox) == 1
+    email = mail.outbox[0]
+    assert "reset your password" in email.subject.lower()
+    assert email.to == ["bob@example.com"]
+
+
+@pytest.mark.django_db
+@patch('core.utils.email_helpers.render_to_string', return_value='Error: boom')
+def test_send_error_email_via_template(mock_render):
+    send_template_email('Error', 'error_email.txt', {'message': 'boom'}, ['dev@example.com'])
+    assert len(mail.outbox) == 1
+    email = mail.outbox[0]
+    assert email.subject == 'Error'
+    assert email.to == ['dev@example.com']
+    assert 'boom' in email.body

--- a/core/tests/test_import_export.py
+++ b/core/tests/test_import_export.py
@@ -1,0 +1,104 @@
+import pandas as pd
+import pytest
+from io import BytesIO
+from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.contrib.auth.models import User
+from core.utils import import_helpers
+from core.models import Account, DatePeriod, Transaction, AccountBalance
+from decimal import Decimal
+
+
+@pytest.mark.django_db
+def test_bulk_importer_valid_creates_accounts_and_periods():
+    user = User.objects.create_user('u')
+    df = pd.DataFrame({
+        'Date': ['2024-01-01', '2024-01-02'],
+        'Type': ['IN', 'EX'],
+        'Amount': [10, 20],
+        'Category': ['Salary', 'Food'],
+        'Account': ['Bank', 'Bank'],
+    })
+    importer = import_helpers.BulkTransactionImporter(user)
+    result = importer.import_dataframe(df)
+    assert result['imported'] == 2
+    assert Account.objects.filter(user=user, name='Bank').exists()
+    assert DatePeriod.objects.filter(year=2024, month=1).exists()
+
+
+@pytest.mark.django_db
+def test_bulk_importer_missing_columns():
+    user = User.objects.create_user('u2')
+    df = pd.DataFrame({'Date': ['2024-01-01'], 'Type': ['IN'], 'Amount': [5], 'Account': ['A']})
+    importer = import_helpers.BulkTransactionImporter(user)
+    result = importer.import_dataframe(df)
+    assert result['errors']
+
+
+@pytest.mark.django_db
+def test_bulk_importer_duplicate_rows():
+    user = User.objects.create_user('u3')
+    df = pd.DataFrame({
+        'Date': ['2024-01-01', '2024-01-01'],
+        'Type': ['IN', 'IN'],
+        'Amount': [10, 10],
+        'Category': ['Salary', 'Salary'],
+        'Account': ['Bank', 'Bank'],
+    })
+    importer = import_helpers.BulkTransactionImporter(user)
+    result = importer.import_dataframe(df)
+    assert result['imported'] == 2
+
+
+@pytest.mark.django_db
+def test_bulk_importer_large_file_chunked():
+    user = User.objects.create_user('u4')
+    rows = 2100
+    df = pd.DataFrame({
+        'Date': ['2024-01-01'] * rows,
+        'Type': ['IN'] * rows,
+        'Amount': [1] * rows,
+        'Category': ['Salary'] * rows,
+        'Account': ['Bank'] * rows,
+    })
+    importer = import_helpers.BulkTransactionImporter(user, batch_size=1000)
+    result = importer.import_dataframe(df)
+    assert result['imported'] == rows
+    assert Transaction.objects.filter(user=user).count() == rows
+
+
+@pytest.mark.django_db
+def test_account_balance_import_and_template(client):
+    user = User.objects.create_user('u5', password='x')
+    client.force_login(user)
+    df = pd.DataFrame({
+        'Year': [2024],
+        'Month': [1],
+        'Account': ['Cash'],
+        'Balance': [100.0],
+    })
+    output = BytesIO()
+    with pd.ExcelWriter(output, engine='openpyxl') as writer:
+        df.to_excel(writer, index=False)
+    output.seek(0)
+    file = SimpleUploadedFile('balances.xlsx', output.read(), content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+    client.post(reverse('account_balance_import_xlsx'), {'file': file}, follow=True)
+    assert AccountBalance.objects.filter(account__user=user, reported_balance=Decimal('100')).exists()
+    response = client.get(reverse('account_balance_template_xlsx'))
+    wb = pd.read_excel(BytesIO(response.content))
+    assert 'Savings' in wb['Account'].tolist()
+
+@pytest.mark.django_db
+def test_account_balance_import_missing_columns(client):
+    user = User.objects.create_user('u6', password='x')
+    client.force_login(user)
+    df = pd.DataFrame({'Year': [2024], 'Month': [1], 'Account': ['Cash']})
+    output = BytesIO()
+    with pd.ExcelWriter(output, engine='openpyxl') as writer:
+        df.to_excel(writer, index=False)
+    output.seek(0)
+    file = SimpleUploadedFile('balances.xlsx', output.read(), content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+    response = client.post(reverse('account_balance_import_xlsx'), {'file': file}, follow=True)
+    from django.contrib.messages import get_messages
+    messages = [m.message for m in get_messages(response.wsgi_request)]
+    assert any('Missing required columns' in m for m in messages)

--- a/core/tests/test_models_core.py
+++ b/core/tests/test_models_core.py
@@ -1,0 +1,98 @@
+import pytest
+from django.contrib.auth.models import User
+from django.db import IntegrityError
+from django.core.exceptions import ValidationError
+from core.models import (
+    Account, AccountType, Category, Tag, Transaction, DatePeriod, UserSettings
+)
+from decimal import Decimal
+from datetime import date
+from django.db import transaction
+
+
+@pytest.mark.django_db
+def test_account_crud_and_unique():
+    user = User.objects.create_user('u1')
+    acc = Account.objects.create(user=user, name='Main')
+    assert acc.currency is not None
+    acc.name = 'Main Updated'
+    acc.save()
+    assert Account.objects.get(pk=acc.pk).name == 'Main Updated'
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            Account.objects.create(user=user, name='Main Updated')
+    acc.delete()
+    assert Account.objects.filter(pk=acc.pk).count() == 0
+
+
+@pytest.mark.django_db
+def test_category_crud_and_unique():
+    user = User.objects.create_user('u2')
+    cat = Category.objects.create(user=user, name='Food')
+    cat.name = 'Food & Drink'
+    cat.save()
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            Category.objects.create(user=user, name='Food & Drink')
+    cat.delete()
+    assert Category.objects.filter(pk=cat.pk).count() == 0
+
+
+@pytest.mark.django_db
+def test_tag_crud_and_unique():
+    user = User.objects.create_user('u3')
+    tag = Tag.objects.create(user=user, name='tag1')
+    tag.name = 'tag2'
+    tag.save()
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            Tag.objects.create(user=user, name='tag2')
+    tag.delete()
+    assert Tag.objects.filter(pk=tag.pk).count() == 0
+
+
+@pytest.mark.django_db
+def test_dateperiod_crud_and_validation():
+    period = DatePeriod.objects.create(year=2024, month=5, label='May 2024')
+    assert period.get_last_day().day in {30, 31}
+    period.label = 'May-2024'
+    period.save()
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            DatePeriod.objects.create(year=2024, month=5, label='dup')
+    with pytest.raises(ValidationError):
+        DatePeriod(year=2024, month=13, label='bad').full_clean()
+    period.delete()
+    assert DatePeriod.objects.filter(pk=period.pk).count() == 0
+
+
+@pytest.mark.django_db
+def test_transaction_crud_and_validation():
+    user = User.objects.create_user('u4')
+    category = Category.objects.create(user=user, name='General')
+    tx = Transaction.objects.create(user=user, date=date(2024,1,10), amount=Decimal('10'), category=category, type=Transaction.Type.EXPENSE)
+    assert tx.period.year == 2024 and tx.period.month == 1
+    tx.amount = Decimal('20')
+    tx.save()
+    with pytest.raises(ValueError):
+        t2 = Transaction(user=user, amount=Decimal('5'), type=Transaction.Type.EXPENSE)
+        t2.save()
+    tx.delete()
+    assert Transaction.objects.filter(pk=tx.pk).count() == 0
+
+
+@pytest.mark.django_db
+def test_usersettings_crud():
+    user = User.objects.create_user('u5')
+    settings = user.settings
+    settings.timezone = 'Europe/Lisbon'
+    settings.save()
+    settings.delete()
+    assert UserSettings.objects.filter(user=user).count() == 0
+
+
+@pytest.mark.django_db
+def test_user_creation_creates_settings_and_cash_account():
+    user = User.objects.create_user('u6')
+    assert hasattr(user, 'settings')
+    assert Account.objects.filter(user=user, name__iexact='cash').exists()

--- a/core/tests/test_security_flows.py
+++ b/core/tests/test_security_flows.py
@@ -1,0 +1,28 @@
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_login_logout_csrf_flow():
+    user = User.objects.create_user('user', password='secret')
+    client = Client(enforce_csrf_checks=True)
+    login_url = reverse('accounts:login')
+    resp = client.get(login_url)
+    csrf_token = resp.cookies['csrftoken'].value
+    resp = client.post(login_url, {'username': 'user', 'password': 'secret'})
+    assert resp.status_code == 403
+    resp = client.post(login_url, {'username': 'user', 'password': 'secret', 'csrfmiddlewaretoken': csrf_token}, HTTP_REFERER='http://testserver/')
+    assert resp.status_code in (302, 303)
+    csrf_token = client.cookies['csrftoken'].value
+    logout_url = reverse('accounts:logout')
+    resp = client.post(logout_url, {'csrfmiddlewaretoken': csrf_token}, HTTP_REFERER='http://testserver/')
+    assert resp.status_code in (302, 303)
+
+
+@pytest.mark.django_db
+def test_anonymous_redirected_from_protected_page(client):
+    resp = client.get(reverse('accounts:profile'))
+    assert resp.status_code == 302
+    assert reverse('accounts:login') in resp['Location']

--- a/core/tests/test_transaction_form.py
+++ b/core/tests/test_transaction_form.py
@@ -1,0 +1,94 @@
+import pytest
+from decimal import Decimal
+from django.contrib.auth.models import User
+from core.forms import TransactionForm
+from core.models import Transaction, Category
+from django.core.exceptions import ValidationError
+
+
+@pytest.mark.django_db
+def test_clean_amount_handles_thousand_and_comma():
+    user = User.objects.create_user('u', password='x')
+    form = TransactionForm(user=user)
+    form.data = {'amount': '1.234,56'}
+    assert form.clean_amount() == Decimal('1234.56')
+
+
+@pytest.mark.django_db
+def test_clean_amount_comma_decimal():
+    user = User.objects.create_user('u2')
+    form = TransactionForm(user=user)
+    form.data = {'amount': '10,50'}
+    assert form.clean_amount() == Decimal('10.50')
+
+
+@pytest.mark.django_db
+def test_negative_amount_not_allowed_for_expense():
+    user = User.objects.create_user('u3')
+    data = {
+        'date': '2024-01-10',
+        'type': Transaction.Type.EXPENSE,
+        'amount': '-5',
+        'period': '2024-01',
+        'category': 'Food',
+    }
+    form = TransactionForm(data=data, user=user)
+    assert not form.is_valid()
+    assert 'amount' in form.errors
+
+
+@pytest.mark.django_db
+def test_direction_applies_sign_for_investment():
+    user = User.objects.create_user('u4')
+    data = {
+        'date': '2024-01-10',
+        'type': Transaction.Type.INVESTMENT,
+        'amount': '100',
+        'direction': 'OUT',
+        'period': '2024-01',
+        'category': 'Invest',
+    }
+    form = TransactionForm(data=data, user=user)
+    assert form.is_valid(), form.errors
+    tx = form.save()
+    assert tx.amount == Decimal('-100')
+
+
+@pytest.mark.django_db
+def test_invalid_and_valid_period():
+    user = User.objects.create_user('u5')
+    data = {
+        'date': '2024-01-10',
+        'type': Transaction.Type.EXPENSE,
+        'amount': '10',
+        'period': 'bad-format',
+        'category': 'Food',
+    }
+    form = TransactionForm(data=data, user=user)
+    assert form.is_valid()
+    with pytest.raises(ValueError):
+        form.save()
+    data['period'] = '2024-12'
+    form = TransactionForm(data=data, user=user)
+    assert form.is_valid()
+    tx = form.save()
+    assert tx.period.month == 12
+
+
+@pytest.mark.django_db
+def test_tags_saved_and_loaded():
+    user = User.objects.create_user('u6')
+    data = {
+        'date': '2024-01-10',
+        'type': Transaction.Type.EXPENSE,
+        'amount': '10',
+        'period': '2024-01',
+        'category': 'Food',
+        'tags_input': 'foo, bar',
+    }
+    form = TransactionForm(data=data, user=user)
+    assert form.is_valid(), form.errors
+    tx = form.save()
+    assert set(tx.tags.values_list('name', flat=True)) == {'foo', 'bar'}
+    edit_form = TransactionForm(user=user, instance=tx)
+    assert set(edit_form.initial['tags_input'].split(', ')) == {'foo', 'bar'}


### PR DESCRIPTION
## Summary
- cover core models with CRUD and constraint tests, ensuring user creation triggers settings and default accounts
- validate TransactionForm parsing, period handling, direction sign, and tag persistence
- exercise bulk Excel importers, account balance import and template, and cache-clearing logic
- test CSP headers, auth flows, and email helpers including activation, password reset, and error notifications

## Testing
- `pytest --cov=core`


------
https://chatgpt.com/codex/tasks/task_e_689fd32133e8832c8a358e00dec41193