### PR TITLE
Add CSP nonce to dynamically loaded transaction list script

### DIFF
--- a/core/static/js/transaction_list_ajax.js
+++ b/core/static/js/transaction_list_ajax.js
@@ -13,6 +13,10 @@
         const script = document.createElement('script');
         script.src = '/static/js/transaction_list_v2.js';
         script.type = 'text/javascript';
-        document.head.appendChild(script);
+        const n = window.CSP_NONCE || null;
+        if (n) {
+            script.setAttribute('nonce', n);
+        }
+        document.body.appendChild(script);
     }
 })();


### PR DESCRIPTION
## Summary
- attach CSP nonce to dynamically injected transaction list script to comply with script-src policies

## Testing
- `pre-commit run --files core/static/js/transaction_list_ajax.js` (no output)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fd68ce16c832cb0f56dcf936052a3