### PR TITLE
Preserve environment CSRF origins in debug

### DIFF
--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -296,7 +296,7 @@ if DEBUG:
     CSRF_FAILURE_VIEW = "django.views.csrf.csrf_failure"
 
     # Origens confiáveis (HTTP + portas)
-    CSRF_TRUSTED_ORIGINS = [
+    CSRF_TRUSTED_ORIGINS += [
         "http://127.0.0.1:8000", "http://127.0.0.1:8001",
         "http://localhost:8000", "http://localhost:8001",
         "http://localhost:3000", "http://127.0.0.1:3000",


### PR DESCRIPTION
## Summary
- extend CSRF trusted origins list in DEBUG mode instead of overwriting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fdc6d8c8c832cac4f24cb57814a3f