### PR TITLE
Remove duplicate healthz route

### DIFF
--- a/core/tests/test_csp_headers.py
+++ b/core/tests/test_csp_headers.py
@@ -9,8 +9,8 @@ class TestCSPHeaders(SimpleTestCase):
 
     def _get_ok_url(self):
         # Prefer a cheap endpoint that returns 200 without auth.
-        # Use /healthz/ if it exists; fallback to "/" otherwise.
-        for url in ("/healthz/", "/"):
+        # Use /healthz if it exists; fallback to "/" otherwise.
+        for url in ("/healthz", "/"):
             resp = self.client.get(url)
             if resp.status_code < 500:
                 return url

--- a/core/urls.py
+++ b/core/urls.py
@@ -147,5 +147,4 @@ urlpatterns = [
 
     # Health check
     path("healthz", healthz, name="healthz"),
-    path("healthz/", healthz),
 ]


### PR DESCRIPTION
## Summary
- remove duplicate `/healthz/` URL entry and keep canonical `/healthz`
- update tests to use canonical health check path

## Testing
- `pre-commit run --files core/urls.py core/tests/test_csp_headers.py --hook-stage pre-push`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fdc727e20832ca7684b1f459edcc9