### PR TITLE
Include Font Awesome stylesheet for icon support

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -17,6 +17,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
 
   {% csrf_token %}
   <meta name="csrf-token" content="{{ csrf_token }}">


### PR DESCRIPTION
## Summary
- load Font Awesome 6.5.2 stylesheet in base template so existing `fas` icons render

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fddc09cd8832ca49060e96935f67d