### PR TITLE
Remove unused dashboard and modal buttons

### DIFF
--- a/core/templates/core/account_balance.html
+++ b/core/templates/core/account_balance.html
@@ -195,22 +195,6 @@
     </form>
   </div>
 </div>
-
-<!-- Delete Confirmation Modal -->
-<div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-labelledby="deleteConfirmModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-narrow">
-    <div class="modal-content modal-rounded">
-      <div class="modal-body text-center py-4">
-        <p class="mb-3 delete-confirm-text">Are you sure you want to delete this balance?</p>
-        <div class="d-flex justify-content-center gap-3">
-          <button type="button" class="btn btn-primary px-4" id="confirm-delete-btn">OK</button>
-          <button type="button" class="btn btn-secondary px-3" data-bs-dismiss="modal">Cancel</button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
 <!-- JS -->
 <script src="{% static 'js/account_balance.js' %}" defer nonce="{{ request.csp_nonce }}"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js" nonce="{{ request.csp_nonce }}"></script>

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -765,9 +765,6 @@ Dashboard{% endblock %} {% block extra_head %}
       >
         <i class="fas fa-filter"></i> Advanced Filters
       </button>
-      <button class="btn btn-outline-info" id="export-report">
-        <i class="fas fa-file-pdf"></i> Report
-      </button>
     </div>
   </div>
 
@@ -1047,9 +1044,6 @@ Dashboard{% endblock %} {% block extra_head %}
             </button>
             <button class="btn btn-outline-secondary" id="export-pdf">
               <i class="fas fa-file-pdf"></i> PDF
-            </button>
-            <button class="btn btn-outline-secondary" id="toggle-details">
-              <i class="fas fa-eye"></i> Details
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- prune unused “Report” and “Details” buttons from dashboard
- drop orphaned delete confirmation modal from account balance page

## Testing
- `pre-commit run --hook-stage pre-push --files core/templates/core/dashboard.html core/templates/core/account_balance.html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06a488028832ca16c9eba959ab494