### PR TITLE
Add pre-login headers

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -6,7 +6,6 @@ Dashboard{% endblock %} {% block extra_head %}
 <meta name="format-detection" content="address=no">
 <meta name="format-detection" content="email=no">
 {% endblock %} {% block content %}
-{% include "core/partials/lazy_instructions.html" %}
 <div class="container-fluid">
   <div class="d-flex align-items-center justify-content-between mb-3 flex-wrap gap-2">
     <div class="btn-group btn-group-sm" role="group">

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -4,4 +4,6 @@
 
 {% block content %}
 {% include "core/partials/lazy_instructions.html" %}
+{% include "core/partials/contact.html" %}
+{% include "core/partials/login_prompt.html" %}
 {% endblock %}

--- a/core/templates/core/partials/contact.html
+++ b/core/templates/core/partials/contact.html
@@ -1,0 +1,6 @@
+<div class="card mb-4">
+  <div class="card-body">
+    <h2 class="h5 mb-2">Need help?</h2>
+    <p class="mb-0">Reach out at <a href="mailto:support@ourfinancetracker.com">support@ourfinancetracker.com</a>.</p>
+  </div>
+</div>

--- a/core/templates/core/partials/login_prompt.html
+++ b/core/templates/core/partials/login_prompt.html
@@ -1,0 +1,11 @@
+<div class="card mb-4">
+  <div class="card-body text-center">
+    <h2 class="h5 mb-3">Ready to manage your finances?</h2>
+    <a href="{% url 'accounts:login' %}" class="btn btn-primary me-2">
+      <i class="bi bi-box-arrow-in-right me-1"></i> Sign in
+    </a>
+    <a href="{% url 'accounts:signup' %}" class="btn btn-outline-primary">
+      <i class="bi bi-person-plus me-1"></i> Sign up
+    </a>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add contact and login prompts to unauthenticated homepage
- remove onboarding instructions from logged-in dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a087c78278832c890759b7dcd1e109