### PR TITLE
Display real calculation for missing transactions

### DIFF
--- a/core/static/js/estimate_transactions.js
+++ b/core/static/js/estimate_transactions.js
@@ -457,6 +457,31 @@ class EstimationManager {
         $('#detail-missing-expenses').text(this.formatCurrency(details.missing_expenses || 0));
         $('#detail-missing-income').text(this.formatCurrency(details.missing_income || 0));
 
+        // Logic explanation for missing transactions
+        const logicExplanationElement = $('#logic-explanation');
+        const logicFormulaElement = $('#logic-formula');
+
+        const expectedExpenses = details.estimated_expenses || 0;
+        const missingExpenses = details.missing_expenses || 0;
+        const missingIncome = details.missing_income || 0;
+
+        const incomeText = this.formatCurrency(combinedIncome);
+        const savingsText = this.formatCurrency(Math.abs(savingsDiff));
+        const investmentText = this.formatCurrency(combinedInvestments);
+        const expectedText = this.formatCurrency(expectedExpenses);
+        const actualExpensesText = this.formatCurrency(combinedExpenses);
+
+        // Show formula for expected expenses
+        logicFormulaElement.text(`${incomeText} ${savingsDiff >= 0 ? '-' : '+'} ${savingsText} - ${investmentText} = ${expectedText}`);
+
+        if (missingExpenses > 0.01) {
+            logicExplanationElement.text(`Recorded expenses (${actualExpensesText}) are lower than expected (${expectedText}), resulting in missing expenses of ${this.formatCurrency(missingExpenses)}.`);
+        } else if (missingIncome > 0.01) {
+            logicExplanationElement.text(`Recorded expenses (${actualExpensesText}) exceed expected (${expectedText}), resulting in missing income of ${this.formatCurrency(missingIncome)}.`);
+        } else {
+            logicExplanationElement.text('Recorded and expected expenses match; no missing transactions detected.');
+        }
+
         // Show modal
         $('#estimationDetailsModal').modal('show');
     }

--- a/core/templates/core/estimate_transactions.html
+++ b/core/templates/core/estimate_transactions.html
@@ -281,14 +281,9 @@
                                                     <i class="fas fa-lightbulb me-1"></i>
                                                     Logic Explanation
                                                 </h6>
-                                                <p class="small mb-0">
-                                                    If your savings increased by €100, and you had €1000 income with €50 investments, 
-                                                    then you should have spent €850 in expenses.
-                                                </p>
+                                                <p class="small mb-0" id="logic-explanation"></p>
                                                 <hr class="my-2 opacity-50">
-                                                <p class="small mb-0">
-                                                    <strong>€1000 - €100 - €50 = €850</strong>
-                                                </p>
+                                                <p class="small mb-0"><strong id="logic-formula"></strong></p>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Summary
- Replace static example in estimation details with dynamic explanation.
- Show formula with real income, savings change, investments, and highlight missing amounts.

## Testing
- `pre-commit run --files core/templates/core/estimate_transactions.html core/static/js/estimate_transactions.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a08aa2db20832cb6afc17ee0ca937a