### PR TITLE
Enable Excel export for Detailed Monthly Analysis

### DIFF
--- a/core/static/js/dashboard.js
+++ b/core/static/js/dashboard.js
@@ -2456,8 +2456,25 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Export functions
-  document.getElementById('export-excel')?.addEventListener('click', () => {
-    window.location.href = '/account-balance/export/';
+  const exportExcelBtn = document.getElementById('export-excel');
+  exportExcelBtn?.addEventListener('click', (e) => {
+    e.preventDefault();
+    const baseUrl = exportExcelBtn.getAttribute('href');
+    if (periodSlider?.noUiSlider) {
+      const [start, end] = periodSlider.noUiSlider.get();
+      const formatPeriodForApi = (period) => {
+        const [month, year] = period.split('/');
+        const fullYear = 2000 + parseInt(year);
+        const monthNum = getMonthNumberInt(month);
+        const monthString = monthNum.toString().padStart(2, '0');
+        return `${fullYear}-${monthString}`;
+      };
+      const startParam = formatPeriodForApi(start);
+      const endParam = formatPeriodForApi(end);
+      window.location.href = `${baseUrl}?start=${startParam}&end=${endParam}`;
+    } else {
+      window.location.href = baseUrl;
+    }
   });
 
   document.getElementById('export-pdf')?.addEventListener('click', () => {

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -1039,9 +1039,13 @@ Dashboard{% endblock %} {% block extra_head %}
             <i class="fas fa-table"></i> Detailed Monthly Analysis
           </h5>
           <div class="btn-group btn-group-sm">
-            <button class="btn btn-outline-secondary" id="export-excel">
+            <a
+              class="btn btn-outline-secondary"
+              id="export-excel"
+              href="{% url 'account_balance_export_xlsx' %}"
+            >
               <i class="fas fa-file-excel"></i> Excel
-            </button>
+            </a>
             <button class="btn btn-outline-secondary" id="export-pdf">
               <i class="fas fa-file-pdf"></i> PDF
             </button>


### PR DESCRIPTION
## Summary
- point the Excel export button to the Django `account_balance_export_xlsx` URL
- read the export URL from the button so selected period range is appended correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a089ccff84832c843d4b02ed28a1af