### PR TITLE
Remove fixed width from account balance drag handle column

### DIFF
--- a/core/static/js/account_balance.js
+++ b/core/static/js/account_balance.js
@@ -140,7 +140,7 @@ function addRow() {
           <table class="table table-hover mb-0">
             <thead class="table-light">
               <tr>
-                <th class="text-center w-40">📱</th>
+                <th class="text-center">📱</th>
                 <th>Account Name</th>
                 <th class="text-end w-180">Balance</th>
                 <th class="text-center w-60">Actions</th>

--- a/core/templates/core/account_balance.html
+++ b/core/templates/core/account_balance.html
@@ -81,7 +81,7 @@
               <table class="table table-hover mb-0">
                 <thead class="table-light">
                   <tr>
-                    <th class="text-center w-40">📱</th>
+                    <th class="text-center">📱</th>
                     <th>Account Name</th>
                     <th class="text-end w-180">Balance</th>
                     <th class="text-center w-60">Actions</th>


### PR DESCRIPTION
## Summary
- Let account balance table drag handle shrink by dropping fixed 40px width
- Update dynamic table template to match

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0b0d8d50c832c9f1bbccfb58d3a59