### PR TITLE
Ensure dashboard KPI progress reflects current values

### DIFF
--- a/core/static/js/dashboard.js
+++ b/core/static/js/dashboard.js
@@ -1026,6 +1026,10 @@ document.addEventListener("DOMContentLoaded", () => {
       new bootstrap.Tooltip(el);
     });
 
+    if (window.recomputeKPICards) {
+      window.recomputeKPICards();
+    }
+
   };
 
   // Helper function to generate enhanced KPI tooltips

--- a/core/static/js/kpi_dashboard.js
+++ b/core/static/js/kpi_dashboard.js
@@ -1,8 +1,9 @@
 (function(){
+  let goals = {};
   function clamp(x){ return Math.max(0, Math.min(100, Math.round(x))); }
   function parseNumberLike(text){
-    return parseFloat((text||"").replace(/[^\d.,-]/g,"" ).replace(/\./g,"").replace(",","."))
-           || parseFloat((text||"").replace(/[^\d.-]/g,"")) || 0;
+    // strip out currency symbols and thousands separators, keep decimal point
+    return parseFloat((text||"").replace(/[^0-9.,-]/g, "").replace(/,/g, "")) || 0;
   }
   function pctFor(actual, goal, mode){
     if (!goal || goal <= 0) return 0;
@@ -57,8 +58,11 @@
   }
 
   document.addEventListener("DOMContentLoaded", async () => {
-    let goals = await fetchGoals();
-    document.querySelectorAll(".kpi-card").forEach(card => recomputeCard(card, goals));
+    goals = await fetchGoals();
+    window.recomputeKPICards = () => {
+      document.querySelectorAll(".kpi-card").forEach(card => recomputeCard(card, goals));
+    };
+    window.recomputeKPICards();
 
     const modalEl = document.getElementById("kpiGoalsModal");
     const form = document.getElementById("kpiGoalsForm");


### PR DESCRIPTION
## Summary
- expose a global helper to recompute KPI card progress using stored goals
- trigger the recomputation after KPI card values update on the dashboard
- strip currency symbols and thousand separators when parsing KPI values so progress reflects real amounts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0b14fbc90832c845be72fc2068588