### PR TITLE
Handle re-estimation correctly

### DIFF
--- a/core/services/finance_estimation.py
+++ b/core/services/finance_estimation.py
@@ -6,6 +6,7 @@ from ..models import DatePeriod, AccountBalance, Transaction, Account
 
 logger = logging.getLogger(__name__)
 
+
 class FinanceEstimationService:
     """Service for financial transaction estimation."""
 
@@ -17,29 +18,28 @@ class FinanceEstimationService:
         try:
             summary = self.get_estimation_summary(period)
 
-            if summary['status'] == 'balanced':
+            if summary["status"] == "balanced":
                 logger.info(f"Period {period.label} is already balanced")
                 return None
 
             # Calculate missing amount
-            missing_amount = summary['estimated_amount']
+            missing_amount = summary["estimated_amount"]
             if abs(missing_amount) < 0.01:  # Ignore very small amounts
                 return None
 
             # Determine transaction type
-            if summary['status'] == 'missing_expenses':
-                tx_type = 'EX'
+            if summary["status"] == "missing_expenses":
+                tx_type = "EX"
                 amount = abs(missing_amount)
-            elif summary['status'] == 'missing_income':
-                tx_type = 'IN'
+            elif summary["status"] == "missing_income":
+                tx_type = "IN"
                 amount = abs(missing_amount)
             else:
                 return None
 
             # Get or create default account
             default_account = Account.objects.filter(
-                user=self.user, 
-                name__icontains='checking'
+                user=self.user, name__icontains="checking"
             ).first()
 
             if not default_account:
@@ -58,10 +58,12 @@ class FinanceEstimationService:
                 notes=f"Estimated {tx_type} transaction for {period.label}",
                 is_estimated=True,
                 period=period,
-                account=default_account
+                account=default_account,
             )
 
-            logger.info(f"Created estimated transaction {estimated_tx.id} for period {period.label}")
+            logger.info(
+                f"Created estimated transaction {estimated_tx.id} for period {period.label}"
+            )
             return estimated_tx
 
         except Exception as e:
@@ -76,22 +78,24 @@ class FinanceEstimationService:
 
             # Get recorded transactions
             transactions = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=False
+                user=self.user, period=period, is_estimated=False
             ).aggregate(
-                income=Sum('amount', filter=Q(type='IN')) or Decimal('0'),
-                expenses=Sum('amount', filter=Q(type='EX')) or Decimal('0'),
-                investments=Sum('amount', filter=Q(type='IV')) or Decimal('0')
+                income=Sum("amount", filter=Q(type="IN")) or Decimal("0"),
+                expenses=Sum("amount", filter=Q(type="EX")) or Decimal("0"),
+                investments=Sum("amount", filter=Q(type="IV")) or Decimal("0"),
             )
 
-            income_inserted = transactions['income'] or Decimal('0')
-            expense_inserted = abs(transactions['expenses'] or Decimal('0'))
-            investment_inserted = transactions['investments'] or Decimal('0')
+            income_inserted = transactions["income"] or Decimal("0")
+            expense_inserted = abs(transactions["expenses"] or Decimal("0"))
+            investment_inserted = transactions["investments"] or Decimal("0")
 
             # Get account balances
             current_savings = self._get_savings_balance(period)
-            next_savings = self._get_savings_balance(next_period) if next_period else current_savings
+            next_savings = (
+                self._get_savings_balance(next_period)
+                if next_period
+                else current_savings
+            )
 
             # Calculate estimated expenses
             savings_diff = next_savings - current_savings
@@ -103,61 +107,61 @@ class FinanceEstimationService:
 
             # Determine status
             if abs(missing_expenses) < 1 and abs(missing_income) < 1:
-                status = 'balanced'
-                status_message = 'All transactions reconciled'
+                status = "balanced"
+                status_message = "All transactions reconciled"
                 estimated_amount = 0
                 estimated_type = None
             elif missing_expenses > 1:
-                status = 'missing_expenses'
-                status_message = f'Missing €{missing_expenses:.2f} in expenses'
+                status = "missing_expenses"
+                status_message = f"Missing €{missing_expenses:.2f} in expenses"
                 estimated_amount = missing_expenses
-                estimated_type = 'EX'
+                estimated_type = "EX"
             else:
-                status = 'missing_income'
-                status_message = f'Missing €{missing_income:.2f} in income'
+                status = "missing_income"
+                status_message = f"Missing €{missing_income:.2f} in income"
                 estimated_amount = missing_income
-                estimated_type = 'IN'
+                estimated_type = "IN"
 
             # Check if estimated transaction exists
             estimated_tx = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=True
+                user=self.user, period=period, is_estimated=True
             ).first()
 
             return {
-                'period_id': period.id,
-                'period': period.label,
-                'status': status,
-                'status_message': status_message,
-                'estimated_amount': float(estimated_amount),
-                'estimated_type': estimated_type,
-                'has_estimated_transaction': estimated_tx is not None,
-                'estimated_transaction_id': estimated_tx.id if estimated_tx else None,
-                'details': {
-                    'income_inserted': float(income_inserted),
-                    'expense_inserted': float(expense_inserted),
-                    'investment_inserted': float(investment_inserted),
-                    'savings_current': float(current_savings),
-                    'savings_next': float(next_savings),
-                    'estimated_expenses': float(estimated_expenses),
-                    'missing_expenses': float(missing_expenses),
-                    'missing_income': float(missing_income)
-                }
+                "period_id": period.id,
+                "period": period.label,
+                "status": status,
+                "status_message": status_message,
+                "estimated_amount": float(estimated_amount),
+                "estimated_type": estimated_type,
+                "has_estimated_transaction": estimated_tx is not None,
+                "estimated_transaction_id": estimated_tx.id if estimated_tx else None,
+                "details": {
+                    "income_inserted": float(income_inserted),
+                    "expense_inserted": float(expense_inserted),
+                    "investment_inserted": float(investment_inserted),
+                    "savings_current": float(current_savings),
+                    "savings_next": float(next_savings),
+                    "estimated_expenses": float(estimated_expenses),
+                    "missing_expenses": float(missing_expenses),
+                    "missing_income": float(missing_income),
+                },
             }
 
         except Exception as e:
-            logger.error(f"Error getting estimation summary for period {period.label}: {e}")
+            logger.error(
+                f"Error getting estimation summary for period {period.label}: {e}"
+            )
             return {
-                'period_id': period.id,
-                'period': period.label,
-                'status': 'error',
-                'status_message': f'Error: {str(e)}',
-                'estimated_amount': 0,
-                'estimated_type': None,
-                'has_estimated_transaction': False,
-                'estimated_transaction_id': None,
-                'details': {}
+                "period_id": period.id,
+                "period": period.label,
+                "status": "error",
+                "status_message": f"Error: {str(e)}",
+                "estimated_amount": 0,
+                "estimated_type": None,
+                "has_estimated_transaction": False,
+                "estimated_transaction_id": None,
+                "details": {},
             }
 
     def _get_next_period(self, period):
@@ -170,10 +174,7 @@ class FinanceEstimationService:
                 next_year = period.year
                 next_month = period.month + 1
 
-            return DatePeriod.objects.filter(
-                year=next_year,
-                month=next_month
-            ).first()
+            return DatePeriod.objects.filter(year=next_year, month=next_month).first()
 
         except Exception:
             return None
@@ -181,22 +182,24 @@ class FinanceEstimationService:
     def _get_savings_balance(self, period):
         """Get total savings balance for a period."""
         if not period:
-            return Decimal('0')
+            return Decimal("0")
 
         try:
             balance = AccountBalance.objects.filter(
                 account__user=self.user,
-                account__account_type__name__icontains='savings',
-                period=period
-            ).aggregate(
-                total=Sum('reported_balance')
-            )['total']
+                account__account_type__name__icontains="savings",
+                period=period,
+            ).aggregate(total=Sum("reported_balance"))["total"]
 
-            return balance or Decimal('0')
+            return balance or Decimal("0")
 
         except Exception as e:
-            logger.error(f"Error getting savings balance for period {period.label}: {e}")
-            return Decimal('0')
+            logger.error(
+                f"Error getting savings balance for period {period.label}: {e}"
+            )
+            return Decimal("0")
+
+
 import logging
 from decimal import Decimal
 from datetime import date
@@ -223,117 +226,119 @@ class FinanceEstimationService:
 
             # Get recorded transactions for the period - separated by estimated vs real
             real_transactions = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=False
+                user=self.user, period=period, is_estimated=False
             ).aggregate(
-                income=Sum('amount', filter=Q(type='IN')) or Decimal('0'),
-                expenses=Sum('amount', filter=Q(type='EX')) or Decimal('0'),
-                investments=Sum('amount', filter=Q(type='IV')) or Decimal('0')
+                income=Sum("amount", filter=Q(type="IN")) or Decimal("0"),
+                expenses=Sum("amount", filter=Q(type="EX")) or Decimal("0"),
+                investments=Sum("amount", filter=Q(type="IV")) or Decimal("0"),
             )
 
             estimated_transactions = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=True
+                user=self.user, period=period, is_estimated=True
             ).aggregate(
-                income=Sum('amount', filter=Q(type='IN')) or Decimal('0'),
-                expenses=Sum('amount', filter=Q(type='EX')) or Decimal('0'),
-                investments=Sum('amount', filter=Q(type='IV')) or Decimal('0')
+                income=Sum("amount", filter=Q(type="IN")) or Decimal("0"),
+                expenses=Sum("amount", filter=Q(type="EX")) or Decimal("0"),
+                investments=Sum("amount", filter=Q(type="IV")) or Decimal("0"),
             )
 
-            # Combined totals for calculations
-            transactions = {
-                'income': (real_transactions['income'] or Decimal('0')) + (estimated_transactions['income'] or Decimal('0')),
-                'expenses': (real_transactions['expenses'] or Decimal('0')) + (estimated_transactions['expenses'] or Decimal('0')),
-                'investments': (real_transactions['investments'] or Decimal('0')) + (estimated_transactions['investments'] or Decimal('0'))
-            }
-
             # Calculate savings difference
-            savings_current = current_balances.get('Savings', Decimal('0'))
-            savings_next = next_balances.get('Savings', Decimal('0'))
+            savings_current = current_balances.get("Savings", Decimal("0"))
+            savings_next = next_balances.get("Savings", Decimal("0"))
             savings_diff = savings_next - savings_current
 
-            # Estimate missing expenses based on savings change
-            income_inserted = abs(transactions['income'] or Decimal('0'))
-            expense_inserted = abs(transactions['expenses'] or Decimal('0'))
-            investment_inserted = transactions['investments'] or Decimal('0')
+            # Use only real transactions when computing missing amounts
+            income_inserted = abs(real_transactions["income"] or Decimal("0"))
+            expense_inserted = abs(real_transactions["expenses"] or Decimal("0"))
+            investment_inserted = real_transactions["investments"] or Decimal("0")
 
             # Calculate expected expenses
             estimated_expenses = income_inserted - savings_diff - investment_inserted
-            missing_expenses = max(Decimal('0'), estimated_expenses - expense_inserted)
+            missing_expenses = max(Decimal("0"), estimated_expenses - expense_inserted)
             # If the recorded expenses exceed the expected value we are actually
             # missing income. Previously this branch only triggered when the
             # estimated expenses were negative which caused periods with extra
             # expenses (e.g. after adding a real transaction on top of an
             # estimated one) to be reported as balanced.  Compare the inserted
             # expenses against the expected amount to detect this situation.
-            missing_income = max(Decimal('0'), expense_inserted - estimated_expenses)
+            missing_income = max(Decimal("0"), expense_inserted - estimated_expenses)
 
             # Check if there's an estimated transaction
             estimated_tx = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=True
+                user=self.user, period=period, is_estimated=True
             ).first()
 
             # Determine status
-            status = 'balanced'
-            status_message = 'Period is balanced'
+            status = "balanced"
+            status_message = "Period is balanced"
             estimated_type = None
-            estimated_amount = Decimal('0')
+            estimated_amount = Decimal("0")
 
             if missing_expenses > 10:  # Threshold for missing expenses
-                status = 'missing_expenses'
-                status_message = f'Missing €{missing_expenses:.0f} in expenses'
-                estimated_type = 'EX'
+                status = "missing_expenses"
+                status_message = f"Missing €{missing_expenses:.0f} in expenses"
+                estimated_type = "EX"
                 estimated_amount = missing_expenses
             elif missing_income > 10:  # Threshold for missing income
-                status = 'missing_income'
-                status_message = f'Missing €{missing_income:.0f} in income'
-                estimated_type = 'IN'
+                status = "missing_income"
+                status_message = f"Missing €{missing_income:.0f} in income"
+                estimated_type = "IN"
                 estimated_amount = missing_income
 
             return {
-                'period_id': period.id,
-                'period': period.label,
-                'status': status,
-                'status_message': status_message,
-                'estimated_type': estimated_type,
-                'estimated_amount': float(estimated_amount),
-                'has_estimated_transaction': estimated_tx is not None,
-                'estimated_transaction_id': estimated_tx.id if estimated_tx else None,
-                'details': {
-                    'income_inserted': float(income_inserted),
-                    'expense_inserted': float(expense_inserted),
-                    'investment_inserted': float(investment_inserted),
-                    'savings_current': float(savings_current),
-                    'savings_next': float(savings_next),
-                    'estimated_expenses': float(estimated_expenses),
-                    'missing_expenses': float(missing_expenses),
-                    'missing_income': float(missing_income),
+                "period_id": period.id,
+                "period": period.label,
+                "status": status,
+                "status_message": status_message,
+                "estimated_type": estimated_type,
+                "estimated_amount": float(estimated_amount),
+                "has_estimated_transaction": estimated_tx is not None,
+                "estimated_transaction_id": estimated_tx.id if estimated_tx else None,
+                "details": {
+                    "income_inserted": float(income_inserted),
+                    "expense_inserted": float(expense_inserted),
+                    "investment_inserted": float(investment_inserted),
+                    "savings_current": float(savings_current),
+                    "savings_next": float(savings_next),
+                    "estimated_expenses": float(estimated_expenses),
+                    "missing_expenses": float(missing_expenses),
+                    "missing_income": float(missing_income),
+                    "currently_estimating": float(estimated_amount),
                     # Real vs Estimated breakdown
-                    'real_income': float(abs(real_transactions['income'] or Decimal('0'))),
-                    'real_expenses': float(abs(real_transactions['expenses'] or Decimal('0'))),
-                    'real_investments': float(real_transactions['investments'] or Decimal('0')),
-                    'estimated_income': float(abs(estimated_transactions['income'] or Decimal('0'))),
-                    'estimated_expenses_tx': float(abs(estimated_transactions['expenses'] or Decimal('0'))),
-                    'estimated_investments': float(estimated_transactions['investments'] or Decimal('0'))
-                }
+                    "real_income": float(
+                        abs(real_transactions["income"] or Decimal("0"))
+                    ),
+                    "real_expenses": float(
+                        abs(real_transactions["expenses"] or Decimal("0"))
+                    ),
+                    "real_investments": float(
+                        real_transactions["investments"] or Decimal("0")
+                    ),
+                    "estimated_income": float(
+                        abs(estimated_transactions["income"] or Decimal("0"))
+                    ),
+                    "estimated_expenses_tx": float(
+                        abs(estimated_transactions["expenses"] or Decimal("0"))
+                    ),
+                    "estimated_investments": float(
+                        estimated_transactions["investments"] or Decimal("0")
+                    ),
+                },
             }
 
         except Exception as e:
-            logger.error(f"Error getting estimation summary for period {period.id}: {e}")
+            logger.error(
+                f"Error getting estimation summary for period {period.id}: {e}"
+            )
             return {
-                'period_id': period.id,
-                'period': period.label,
-                'status': 'error',
-                'status_message': f'Error: {str(e)}',
-                'estimated_type': None,
-                'estimated_amount': 0,
-                'has_estimated_transaction': False,
-                'estimated_transaction_id': None,
-                'details': {}
+                "period_id": period.id,
+                "period": period.label,
+                "status": "error",
+                "status_message": f"Error: {str(e)}",
+                "estimated_type": None,
+                "estimated_amount": 0,
+                "has_estimated_transaction": False,
+                "estimated_transaction_id": None,
+                "details": {},
             }
 
     def get_period_balances(self, period):
@@ -342,14 +347,17 @@ class FinanceEstimationService:
             return {}
 
         with connection.cursor() as cursor:
-            cursor.execute("""
+            cursor.execute(
+                """
                 SELECT at.name, SUM(ab.reported_balance)
                 FROM core_accountbalance ab
                 INNER JOIN core_account a ON ab.account_id = a.id
                 INNER JOIN core_accounttype at ON a.account_type_id = at.id
                 WHERE a.user_id = %s AND ab.period_id = %s
                 GROUP BY at.name
-            """, [self.user.id, period.id])
+            """,
+                [self.user.id, period.id],
+            )
 
             balances = {}
             for account_type, balance in cursor.fetchall():
@@ -372,19 +380,21 @@ class FinanceEstimationService:
         try:
             # Find and delete estimated transactions for this period and user
             estimated_transactions = Transaction.objects.filter(
-                user=self.user,
-                period=period,
-                is_estimated=True
+                user=self.user, period=period, is_estimated=True
             )
 
             deleted_count = estimated_transactions.count()
             estimated_transactions.delete()
 
-            logger.info(f"Deleted {deleted_count} estimated transaction(s) for period {period.label}")
+            logger.info(
+                f"Deleted {deleted_count} estimated transaction(s) for period {period.label}"
+            )
             return deleted_count
 
         except Exception as e:
-            logger.error(f"Error deleting estimated transactions for period {period.id}: {e}")
+            logger.error(
+                f"Error deleting estimated transactions for period {period.id}: {e}"
+            )
             raise
 
     def estimate_transaction_for_period(self, period):
@@ -392,7 +402,7 @@ class FinanceEstimationService:
         try:
             summary = self.get_estimation_summary(period)
 
-            if summary['status'] == 'error' or summary['estimated_amount'] <= 10:
+            if summary["status"] == "error" or summary["estimated_amount"] <= 10:
                 return None
 
             # Delete existing estimated transaction using the service method
@@ -403,8 +413,7 @@ class FinanceEstimationService:
 
             # Get or create estimation category
             category, _ = Category.objects.get_or_create(
-                name='Estimated Transaction',
-                user=self.user
+                name="Estimated Transaction", user=self.user
             )
 
             # Get default account
@@ -414,17 +423,19 @@ class FinanceEstimationService:
 
             estimated_tx = Transaction.objects.create(
                 user=self.user,
-                type=summary['estimated_type'],
-                amount=Decimal(str(summary['estimated_amount'])),
+                type=summary["estimated_type"],
+                amount=Decimal(str(summary["estimated_amount"])),
                 date=date(period.year, period.month, 15),  # Mid-month
                 notes=f"Estimated {summary['estimated_type']} for {period.label}",
                 is_estimated=True,
                 period=period,
                 account=account,
-                category=category
+                category=category,
             )
 
-            logger.info(f"Created estimated transaction {estimated_tx.id} for period {period.label}")
+            logger.info(
+                f"Created estimated transaction {estimated_tx.id} for period {period.label}"
+            )
             return estimated_tx
 
         except Exception as e:

--- a/core/static/js/estimate_transactions.js
+++ b/core/static/js/estimate_transactions.js
@@ -457,6 +457,10 @@ class EstimationManager {
         $('#detail-missing-expenses').text(this.formatCurrency(parseFloat(details.missing_expenses || 0)));
         $('#detail-missing-income').text(this.formatCurrency(parseFloat(details.missing_income || 0)));
 
+        // Amount that will be estimated
+        const currentlyEstimating = parseFloat(details.currently_estimating || 0);
+        $('#detail-currently-estimating').text(this.formatCurrency(currentlyEstimating));
+
         // Logic explanation for missing transactions
         const logicExplanationElement = $('#logic-explanation');
         const logicFormulaElement = $('#logic-formula');

--- a/core/templates/core/estimate_transactions.html
+++ b/core/templates/core/estimate_transactions.html
@@ -322,7 +322,17 @@
                                             </div>
                                         </div>
                                     </div>
-                                    
+
+                                    <div class="row mb-3">
+                                        <div class="col-12">
+                                            <div class="alert alert-secondary text-center">
+                                                <h6 class="alert-heading">Currently Estimating</h6>
+                                                <div class="h4 mb-0" id="detail-currently-estimating">€0.00</div>
+                                                <small>Value after estimate/re-estimate</small>
+                                            </div>
+                                        </div>
+                                    </div>
+
                                     <div class="alert alert-info mb-0">
                                         <div class="d-flex align-items-start">
                                             <i class="fas fa-robot me-2 mt-1"></i>

--- a/core/tests/test_estimate_transactions.py
+++ b/core/tests/test_estimate_transactions.py
@@ -60,7 +60,9 @@ def set_balance(account: Account, period: DatePeriod, amount: Decimal) -> None:
         balance.save(update_fields=["reported_balance"])
 
 
-def make_tx(*, user, account, category, period, amount, tx_type="EX", is_estimated=False):
+def make_tx(
+    *, user, account, category, period, amount, tx_type="EX", is_estimated=False
+):
     return Transaction.objects.create(
         user=user,
         account=account,
@@ -99,19 +101,26 @@ def test_estimate_creates_single_estimated_transaction_for_period(
     tx1 = run_estimate_for(client, period_aug)
     assert tx1 is not None
     assert (
-        Transaction.objects.filter(user=user, period=period_aug, is_estimated=True).count()
+        Transaction.objects.filter(
+            user=user, period=period_aug, is_estimated=True
+        ).count()
         == 1
     )
 
     run_estimate_for(client, period_aug)
     assert (
-        Transaction.objects.filter(user=user, period=period_aug, is_estimated=True).count()
+        Transaction.objects.filter(
+            user=user, period=period_aug, is_estimated=True
+        ).count()
         == 1
     )
 
 
 @pytest.mark.django_db
-@pytest.mark.skipif(connection.vendor == "sqlite", reason="transactions_json_v2 uses PostgreSQL-specific SQL")
+@pytest.mark.skipif(
+    connection.vendor == "sqlite",
+    reason="transactions_json_v2 uses PostgreSQL-specific SQL",
+)
 def test_estimated_transaction_is_visible_on_transactions_v2_page(
     client, user, savings_account
 ):
@@ -160,10 +169,14 @@ def test_manual_transaction_after_estimate_triggers_reestimate_warning(
     summary = service.get_estimation_summary(period_aug)
     assert summary["has_estimated_transaction"] is True
     assert summary["status"] != "balanced"
+    assert Decimal(str(summary["estimated_amount"])) == Decimal("150")
 
 
 @pytest.mark.django_db
-@pytest.mark.skipif(connection.vendor == "sqlite", reason="transactions_json_v2 uses PostgreSQL-specific SQL")
+@pytest.mark.skipif(
+    connection.vendor == "sqlite",
+    reason="transactions_json_v2 uses PostgreSQL-specific SQL",
+)
 def test_reestimate_replaces_previous_estimate_and_keeps_single_per_period(
     client, user, savings_account, category
 ):


### PR DESCRIPTION
## Summary
- Ignore existing estimated transactions when computing period summaries
- Surface the amount to be estimated in the transaction estimation modal
- Cover re-estimation scenario in tests

## Testing
- `pre-commit run --hook-stage pre-push --files core/services/finance_estimation.py core/templates/core/estimate_transactions.html core/static/js/estimate_transactions.js core/tests/test_estimate_transactions.py`
- `pytest core/tests/test_estimate_transactions.py::test_manual_transaction_after_estimate_triggers_reestimate_warning -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0cdc156a4832ca41ae5c08630c122