### PR TITLE
Tidy estimation summary and balance logic

### DIFF
--- a/core/templates/core/estimate_transactions.html
+++ b/core/templates/core/estimate_transactions.html
@@ -87,6 +87,9 @@
                             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
                         </div>
                         <div class="modal-body">
+                            <div class="alert alert-secondary text-center mb-4">
+                                <h6 class="mb-0">Currently Estimating: <span id="detail-currently-estimating">€0.00</span></h6>
+                            </div>
                             <!-- Period Info Header -->
                             <div class="alert alert-primary mb-4">
                                 <div class="d-flex align-items-center">
@@ -319,16 +322,6 @@
                                                 </h6>
                                                 <div class="h4 text-success" id="detail-missing-income">€0.00</div>
                                                 <small>Income you may have forgotten to record</small>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <div class="row mb-3">
-                                        <div class="col-12">
-                                            <div class="alert alert-secondary text-center">
-                                                <h6 class="alert-heading">Currently Estimating</h6>
-                                                <div class="h4 mb-0" id="detail-currently-estimating">€0.00</div>
-                                                <small>Value after estimate/re-estimate</small>
                                             </div>
                                         </div>
                                     </div>

--- a/core/tests/test_estimate_transactions.py
+++ b/core/tests/test_estimate_transactions.py
@@ -146,6 +146,22 @@ def test_estimated_transaction_is_visible_on_transactions_v2_page(
 
 
 @pytest.mark.django_db
+def test_estimate_marks_period_balanced_when_missing_covered(
+    client, user, savings_account
+):
+    period_aug = make_period("2025-08")
+    period_sep = make_period("2025-09")
+    set_balance(savings_account, period_aug, Decimal("1000"))
+    set_balance(savings_account, period_sep, Decimal("800"))
+
+    run_estimate_for(client, period_aug)
+    service = FinanceEstimationService(user)
+    summary = service.get_estimation_summary(period_aug)
+    assert summary["status"] == "balanced"
+    assert Decimal(str(summary["details"]["currently_estimating"])) == Decimal("200")
+
+
+@pytest.mark.django_db
 def test_manual_transaction_after_estimate_triggers_reestimate_warning(
     client, user, savings_account, category
 ):


### PR DESCRIPTION
## Summary
- Show current estimation amount directly under Financial Estimation Details title
- Mark period balanced when existing estimated amount covers missing values and expose current estimate
- Test that balanced status is returned when missing is fully covered

## Testing
- `pre-commit run --files core/services/finance_estimation.py core/templates/core/estimate_transactions.html core/tests/test_estimate_transactions.py`
- `pytest core/tests/test_estimate_transactions.py::test_estimate_marks_period_balanced_when_missing_covered core/tests/test_estimate_transactions.py::test_manual_transaction_after_estimate_triggers_reestimate_warning -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d06b9244832cafe8c0a736f69e39