### PR TITLE
Strengthen account tests

### DIFF
--- a/accounts/tests/test_delete_account.py
+++ b/accounts/tests/test_delete_account.py
@@ -31,3 +31,15 @@ def test_delete_account_view_invalid_referer(client, settings):
     )
     assert response.status_code == 302
     assert response.url == reverse("home") + "?delete_error=1"
+
+
+@pytest.mark.django_db
+def test_delete_account_requires_login(client, settings):
+    settings.SECURE_SSL_REDIRECT = False
+    response = client.post(
+        reverse("accounts:delete_account"),
+        {"password": "secret", "confirmation": "DELETE"},
+    )
+    assert response.status_code == 302
+    login_url = f"{reverse('accounts:login')}?next={reverse('accounts:delete_account')}"
+    assert response.url == login_url

--- a/accounts/tests/test_profile_view.py
+++ b/accounts/tests/test_profile_view.py
@@ -19,3 +19,4 @@ def test_profile_renders_for_authenticated_user(client, settings):
     response = client.get(reverse("accounts:profile"))
     assert response.status_code == 200
     assert "accounts/profile.html" in [t.name for t in response.templates]
+    assert "Username: tester" in response.content.decode()


### PR DESCRIPTION
## Summary
- assert profile page shows logged user's username
- ensure delete account view redirects unauthenticated users to login

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite:////tmp/testdb.sqlite3 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0f1fc62e8832ca3523255a361d6bf