### PR TITLE
Use generic signup error messages

### DIFF
--- a/accounts/tests/test_signup_validation.py
+++ b/accounts/tests/test_signup_validation.py
@@ -10,7 +10,8 @@ def test_signup_missing_username(client):
     assert response.status_code == 400
     assert User.objects.count() == 0
     messages = list(response.context["messages"])
-    assert any("username" in str(m) for m in messages)
+    assert any("Invalid data" in str(m) for m in messages)
+    assert all("username" not in str(m) for m in messages)
 
 
 @pytest.mark.django_db
@@ -20,4 +21,29 @@ def test_signup_invalid_email(client):
     assert response.status_code == 400
     assert User.objects.count() == 0
     messages = list(response.context["messages"])
-    assert any("email" in str(m) for m in messages)
+    assert any("Invalid data" in str(m) for m in messages)
+    assert all("email" not in str(m) for m in messages)
+
+
+@pytest.mark.django_db
+def test_signup_duplicate_username(client):
+    User.objects.create_user(username="existing", email="exist@example.com", password="StrongPass123!")
+    data = {"username": "existing", "email": "new@example.com", "password": "StrongPass123!"}
+    response = client.post(reverse("accounts:signup"), data)
+    assert response.status_code == 400
+    assert User.objects.filter(username="existing").count() == 1
+    messages = list(response.context["messages"])
+    assert any("Invalid data" in str(m) for m in messages)
+    assert all("username" not in str(m) for m in messages)
+
+
+@pytest.mark.django_db
+def test_signup_duplicate_email(client):
+    User.objects.create_user(username="user1", email="dup@example.com", password="StrongPass123!")
+    data = {"username": "user2", "email": "dup@example.com", "password": "StrongPass123!"}
+    response = client.post(reverse("accounts:signup"), data)
+    assert response.status_code == 400
+    assert User.objects.filter(email="dup@example.com").count() == 1
+    messages = list(response.context["messages"])
+    assert any("Invalid data" in str(m) for m in messages)
+    assert all("email" not in str(m) for m in messages)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -36,9 +36,7 @@ def signup(request):
     form = SignupForm(request.POST or None)
     if request.method == "POST":
         if not form.is_valid():
-            for field, errors in form.errors.items():
-                for error in errors:
-                    messages.error(request, f"{field}: {error}")
+            messages.error(request, "Invalid data")
             return render(request, "accounts/signup.html", {"form": form}, status=400)
 
         username = form.cleaned_data["username"]
@@ -46,15 +44,15 @@ def signup(request):
         password = form.cleaned_data["password"]
 
         if User.objects.filter(username__iexact=username).exists():
-            messages.error(request, "This username is already taken. Please choose another one.")
+            messages.error(request, "Invalid data")
             return render(request, "accounts/signup.html", {"form": form}, status=400)
 
-        # Se já existir conta ativa com este email
+        # If an active account already exists with this email
         if User.objects.filter(email__iexact=email, is_active=True).exists():
-            messages.error(request, "An account with this email already exists. Try resetting your password.")
+            messages.error(request, "Invalid data")
             return render(request, "accounts/signup.html", {"form": form}, status=400)
 
-        # Se existir conta inativa com o mesmo email, reenvia ativação em vez de criar nova
+        # If an inactive account exists with the same email, resend activation instead of creating a new one
         existing_inactive = User.objects.filter(email__iexact=email, is_active=False).first()
         if existing_inactive:
             # Generate activation token for existing user
@@ -107,7 +105,7 @@ def signup(request):
                     username=username, email=email, password=password, is_active=False
                 )
         except IntegrityError:
-            messages.error(request, "This username is already taken. Please choose another one.")
+            messages.error(request, "Invalid data")
             return render(request, "accounts/signup.html", {"form": form}, status=400)
 
         # Generate activation token


### PR DESCRIPTION
## Summary
- Return a generic "Invalid data" message for all signup validation failures, including duplicate username or email
- Harden tests to ensure detailed signup error messages are no longer exposed

## Testing
- `pytest accounts/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1086683f4832cac55722e69a207ad