### PR TITLE
Add IP-based rate limiting for auth endpoints

### DIFF
--- a/accounts/tests/test_rate_limit.py
+++ b/accounts/tests/test_rate_limit.py
@@ -1,0 +1,39 @@
+import pytest
+from django.urls import reverse
+from django.core.cache import cache
+
+
+@pytest.mark.django_db
+def test_login_rate_limit(client, settings):
+    """Blocks login after exceeding the attempt limit."""
+    settings.AXES_ENABLED = False
+    middleware = list(settings.MIDDLEWARE)
+    idx = middleware.index("axes.middleware.AxesMiddleware")
+    middleware.insert(idx, "core.middleware.rate_limiting.RateLimitMiddleware")
+    settings.MIDDLEWARE = middleware
+    cache.clear()
+    url = reverse("accounts:login")
+    data = {"username": "tester", "password": "wrong"}
+    for _ in range(5):
+        client.post(url, data)
+    response = client.post(url, data)
+    assert response.status_code == 429
+    assert response.json()["detail"] == "Too many requests"
+
+
+@pytest.mark.django_db
+def test_signup_rate_limit(client, settings):
+    """Blocks signup after exceeding the attempt limit."""
+    settings.AXES_ENABLED = False
+    middleware = list(settings.MIDDLEWARE)
+    idx = middleware.index("axes.middleware.AxesMiddleware")
+    middleware.insert(idx, "core.middleware.rate_limiting.RateLimitMiddleware")
+    settings.MIDDLEWARE = middleware
+    cache.clear()
+    url = reverse("accounts:signup")
+    data = {}
+    for _ in range(5):
+        client.post(url, data)
+    response = client.post(url, data)
+    assert response.status_code == 429
+    assert response.json()["detail"] == "Too many requests"


### PR DESCRIPTION
## Summary
- extend rate limiting middleware with IP- and username-based rules for `/accounts/login/` and `/accounts/signup/`
- use atomic cache counters to track attempts and return HTTP 429 on limit exceed
- add tests covering repeated login and signup attempts
- refine middleware comment and test docstrings to ensure English wording

## Testing
- `pytest accounts/tests/test_rate_limit.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a108674c20832cbe00e31812b0e3a6