### PR TITLE
Use PasswordResetTokenGenerator for account activation

### DIFF
--- a/accounts/tests/test_activate_view.py
+++ b/accounts/tests/test_activate_view.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 from django.utils.http import urlsafe_base64_encode
 from django.utils.encoding import force_bytes
 
-from accounts.tokens import generate_activation_token
+from accounts.tokens import activation_token_generator
 
 
 @pytest.mark.django_db
@@ -13,7 +13,7 @@ def test_activate_view_with_valid_token(client, settings):
     user = User.objects.create_user(
         username="newuser", email="new@example.com", password="pass", is_active=False
     )
-    token = generate_activation_token(user)
+    token = activation_token_generator.make_token(user)
     uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
 
     response = client.get(reverse("accounts:activate", kwargs={"uidb64": uidb64, "token": token}))

--- a/accounts/tests/test_activation_token.py
+++ b/accounts/tests/test_activation_token.py
@@ -1,12 +1,15 @@
 import pytest
 from django.contrib.auth.models import User
-from accounts.tokens import generate_activation_token, validate_activation_token, revoke_activation_token
+from accounts.tokens import activation_token_generator
 
 
 @pytest.mark.django_db
-def test_activation_token_cycle():
-    user = User.objects.create_user(username="u1", password="pw", email="u1@example.com", is_active=False)
-    token = generate_activation_token(user)
-    assert validate_activation_token(user, token)
-    revoke_activation_token(user)
-    assert not validate_activation_token(user, token)
+def test_activation_token_invalid_after_activation():
+    user = User.objects.create_user(
+        username="u1", password="pw", email="u1@example.com", is_active=False
+    )
+    token = activation_token_generator.make_token(user)
+    assert activation_token_generator.check_token(user, token)
+    user.is_active = True
+    user.save()
+    assert not activation_token_generator.check_token(user, token)

--- a/accounts/tokens.py
+++ b/accounts/tokens.py
@@ -1,31 +1,11 @@
-import hashlib
-import secrets
-from django.core.cache import cache
-from django.conf import settings
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
 
 
-def _cache_key(user_id: int) -> str:
-    return f"activation:{user_id}"
+class ActivationTokenGenerator(PasswordResetTokenGenerator):
+    """Token generator that invalidates tokens once the user is activated."""
+
+    def _make_hash_value(self, user, timestamp):  # type: ignore[override]
+        return f"{user.pk}{timestamp}{user.is_active}"
 
 
-def generate_activation_token(user) -> str:
-    """Generate a secure activation token for ``user`` and store its hash."""
-    token = secrets.token_urlsafe(32)
-    token_hash = hashlib.sha256(token.encode()).hexdigest()
-    timeout = int(getattr(settings, "ACCOUNT_ACTIVATION_TOKEN_EXPIRATION_SECONDS", 900))
-    cache.set(_cache_key(user.pk), token_hash, timeout)
-    return token
-
-
-def validate_activation_token(user, token: str) -> bool:
-    """Check whether ``token`` matches the stored hash for ``user``."""
-    token_hash = cache.get(_cache_key(user.pk))
-    if not token_hash:
-        return False
-    candidate = hashlib.sha256(token.encode()).hexdigest()
-    return secrets.compare_digest(token_hash, candidate)
-
-
-def revoke_activation_token(user) -> None:
-    """Manually revoke ``user``'s activation token."""
-    cache.delete(_cache_key(user.pk))
+activation_token_generator = ActivationTokenGenerator()

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -18,13 +18,7 @@ from django.db import transaction, IntegrityError
 from django.contrib import messages
 from django.conf import settings
 from django.core.cache import cache
-from django.utils import timezone
-from datetime import timedelta
-from .tokens import (
-    generate_activation_token,
-    validate_activation_token,
-    revoke_activation_token,
-)
+from .tokens import activation_token_generator
 from .forms import SignupForm
 
 logger = logging.getLogger(__name__)
@@ -49,17 +43,19 @@ def signup(request):
             messages.error(request, "This username is already taken. Please choose another one.")
             return render(request, "accounts/signup.html", {"form": form}, status=400)
 
-        # Se já existir conta ativa com este email
+        # If an active account already exists with this email
         if User.objects.filter(email__iexact=email, is_active=True).exists():
-            messages.error(request, "An account with this email already exists. Try resetting your password.")
+            messages.error(
+                request,
+                "An account with this email already exists. Try resetting your password.",
+            )
             return render(request, "accounts/signup.html", {"form": form}, status=400)
 
-        # Se existir conta inativa com o mesmo email, reenvia ativação em vez de criar nova
+        # If an inactive account exists with the same email, resend activation instead of creating a new one
         existing_inactive = User.objects.filter(email__iexact=email, is_active=False).first()
         if existing_inactive:
             # Generate activation token for existing user
-            revoke_activation_token(existing_inactive)
-            token = generate_activation_token(existing_inactive)
+            token = activation_token_generator.make_token(existing_inactive)
             uid = urlsafe_base64_encode(force_bytes(existing_inactive.pk))
 
             # Send activation email
@@ -91,7 +87,6 @@ def signup(request):
                 )
             except (smtplib.SMTPException, BadHeaderError) as e:
                 logger.exception("Email sending failed: %s", e)
-                revoke_activation_token(existing_inactive)
                 messages.error(
                     request,
                     "There was an error sending the activation email. Please try again later.",
@@ -111,7 +106,7 @@ def signup(request):
             return render(request, "accounts/signup.html", {"form": form}, status=400)
 
         # Generate activation token
-        token = generate_activation_token(user)
+        token = activation_token_generator.make_token(user)
         uid = urlsafe_base64_encode(force_bytes(user.pk))
 
         # Send activation email
@@ -143,7 +138,6 @@ def signup(request):
             )
         except (smtplib.SMTPException, BadHeaderError) as e:
             logger.exception("Email sending failed: %s", e)
-            revoke_activation_token(user)
             messages.error(
                 request,
                 "There was an error sending the activation email. Please try again later.",
@@ -172,8 +166,7 @@ def activate(request, uidb64, token):
     except Exception as exc:
         logger.warning("Activation: could not resolve user from uidb64=%s (%s)", uidb64, exc)
 
-    if user and validate_activation_token(user, token):
-        revoke_activation_token(user)
+    if user and activation_token_generator.check_token(user, token):
         if not user.is_active:
             user.is_active = True
             user.save(update_fields=["is_active"])

--- a/core/utils/email_helpers.py
+++ b/core/utils/email_helpers.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
-from accounts.tokens import generate_activation_token, revoke_activation_token
+from accounts.tokens import activation_token_generator
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ def send_account_activation_email(user, request):
         ``False``.
     """
     uid = urlsafe_base64_encode(force_bytes(user.pk))
-    token = generate_activation_token(user)
+    token = activation_token_generator.make_token(user)
     activation_link = request.build_absolute_uri(
         reverse("accounts:activate", kwargs={"uidb64": uid, "token": token})
     )
@@ -98,7 +98,6 @@ def send_account_activation_email(user, request):
         logger.info("Activation email sent to %s", user.email)
         return True
     except (smtplib.SMTPException, BadHeaderError) as exc:
-        revoke_activation_token(user)
         logger.error("Failed to send activation email to %s: %s", user.email, exc)
         return False
 


### PR DESCRIPTION
## Summary
- Replace custom cache-based activation tokens with Django's `PasswordResetTokenGenerator`
- Generate activation tokens and links in signup flow with the native generator
- Validate activation links using the same generator and update email helper
- Adjust tests to cover the new token lifecycle
- Translate signup view comments to English

## Testing
- `pre-commit run --hook-stage pre-push --files accounts/views.py`
- `pytest accounts/tests`
- `pytest core/tests/test_email_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a108680600832ca6cb9ea5173a2166