### PR TITLE
Enforce SameSite=Strict cookies by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ EXTRA_CSRF_TRUSTED_ORIGINS=https://example.com,https://sub.domain.com
 
 Use comma-separated values. For `EXTRA_CSRF_TRUSTED_ORIGINS`, each origin must include the scheme (`http://` or `https://`).
 
+## 🍪 Cookie policy and integrations
+
+The application now sets both session and CSRF cookies with `SameSite=Strict` to mitigate cross-site request forgery. This can
+affect integrations that rely on cross-site requests or iframes. If an integration requires a more permissive policy, the
+behaviour can be overridden via environment variables:
+
+```bash
+SESSION_COOKIE_SAMESITE=Lax
+CSRF_COOKIE_SAMESITE=Lax
+```
+
+Use `None`, `Lax`, or `Strict` as needed.
+
 ## 📄 Licence
 
 Distributed under the MIT licence. See the `LICENSE` file for more details.

--- a/core/tests/test_cookie_samesite.py
+++ b/core/tests/test_cookie_samesite.py
@@ -1,0 +1,24 @@
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_session_and_csrf_cookies_use_samesite_strict():
+    user = User.objects.create_user('user', password='secret')
+    client = Client(enforce_csrf_checks=True)
+
+    login_url = reverse('accounts:login')
+    resp = client.get(login_url)
+    assert resp.cookies['csrftoken']['samesite'] == 'Strict'
+    csrf_token = resp.cookies['csrftoken'].value
+
+    resp = client.post(
+        login_url,
+        {'username': 'user', 'password': 'secret', 'csrfmiddlewaretoken': csrf_token},
+        HTTP_REFERER='http://testserver/',
+    )
+    # login sets the session cookie
+    assert resp.cookies['sessionid']['samesite'] == 'Strict'
+

--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -1,6 +1,6 @@
 """
-Django settings.py — consolidado para DEV/PROD com Supabase Postgres,
-CSP (django-csp), WhiteNoise, Redis opcional, Debug Toolbar e django-axes.
+Django settings.py — consolidated for DEV/PROD with Supabase Postgres,
+CSP (django-csp), WhiteNoise, optional Redis, Debug Toolbar, and django-axes.
 """
 
 from __future__ import annotations
@@ -94,7 +94,7 @@ INSTALLED_APPS = [
     "django.contrib.admin", "django.contrib.auth", "django.contrib.contenttypes",
     "django.contrib.sessions", "django.contrib.messages", "django.contrib.staticfiles",
     "django.contrib.sites",
-    # Terceiros
+    # Third-party
     "whitenoise.runserver_nostatic",
     "widget_tweaks",
     "django.contrib.humanize",
@@ -102,7 +102,7 @@ INSTALLED_APPS = [
     "axes",
     "anymail",
     "django_celery_beat",
-    # Projeto
+    # Project
     "accounts",
     "core",
 ]
@@ -125,7 +125,7 @@ MIDDLEWARE = [
 ]
 if DEBUG:
     MIDDLEWARE.append("core.middleware.performance.PerformanceMiddleware")
-MIDDLEWARE.append("axes.middleware.AxesMiddleware")  # axes por último
+MIDDLEWARE.append("axes.middleware.AxesMiddleware")  # axes middleware must come last
 
 if DEBUG and SHOW_DEBUG_TOOLBAR:
     MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
@@ -159,7 +159,7 @@ TEMPLATES = [
 ]
 
 # ────────────────────────────────────────────────────
-# Base de dados (Supabase prioritário via SUPABASE_DB_URL/DATABASE_URL; fallback SQLite)
+# Database (Supabase preferred via SUPABASE_DB_URL/DATABASE_URL; fallback SQLite)
 # ────────────────────────────────────────────────────
 SUPA_URL = ENV("SUPABASE_DB_URL") or ENV("DATABASE_URL")
 if not SUPA_URL and ENV("DB_HOST"):
@@ -182,7 +182,7 @@ else:
     }
 
 # ────────────────────────────────────────────────────
-# Cache (Redis opcional)
+# Cache (optional Redis)
 # ────────────────────────────────────────────────────
 if ENV("REDIS_URL"):
     CACHES = {
@@ -244,7 +244,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 # ────────────────────────────────────────────────────
-# Security profiles (DEV/PROD): HTTPS, Cookies/CSRF e CSP
+# Security profiles (DEV/PROD): HTTPS, Cookies/CSRF, and CSP
 # ────────────────────────────────────────────────────
 # --- CSP base policy ---
 CONTENT_SECURITY_POLICY = {
@@ -281,21 +281,22 @@ CONTENT_SECURITY_POLICY = {
 if not DEBUG:
     CONTENT_SECURITY_POLICY["DIRECTIVES"]["upgrade-insecure-requests"] = []
 
+SESSION_COOKIE_SAMESITE = ENV("SESSION_COOKIE_SAMESITE", "Strict")
+CSRF_COOKIE_SAMESITE = ENV("CSRF_COOKIE_SAMESITE", "Strict")
+
 if DEBUG:
-    # Dev: sem HTTPS forçado
+    # Dev: no forced HTTPS
     SECURE_SSL_REDIRECT = False
     SECURE_PROXY_SSL_HEADER = None
 
-    # Cookies & CSRF em HTTP
+    # Cookies & CSRF over HTTP
     SESSION_COOKIE_SECURE = False
     CSRF_COOKIE_SECURE = False
-    SESSION_COOKIE_SAMESITE = "Lax"
-    CSRF_COOKIE_SAMESITE = "Lax"
     CSRF_COOKIE_HTTPONLY = False
     CSRF_USE_SESSIONS = False
     CSRF_FAILURE_VIEW = "django.views.csrf.csrf_failure"
 
-    # Origens confiáveis (HTTP + portas)
+    # Trusted origins (HTTP + ports)
     CSRF_TRUSTED_ORIGINS += [
         "http://127.0.0.1:8000", "http://127.0.0.1:8001",
         "http://localhost:8000", "http://localhost:8001",
@@ -303,7 +304,7 @@ if DEBUG:
     ]
 
 else:
-    # Prod: HTTPS obrigatório e cabeçalhos fortes
+    # Prod: enforce HTTPS and strong headers
     SECURE_SSL_REDIRECT = True
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     SECURE_HSTS_SECONDS = 31536000
@@ -318,10 +319,8 @@ else:
     # Cookies & CSRF
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
-    SESSION_COOKIE_SAMESITE = "Lax"
-    CSRF_COOKIE_SAMESITE = "Lax"
     SESSION_COOKIE_HTTPONLY = True
-    CSRF_COOKIE_HTTPONLY = True  # muda para False se precisares de ler via JS
+    CSRF_COOKIE_HTTPONLY = True  # set to False if JS needs to read it
 
 
 # ────────────────────────────────────────────────────
@@ -345,12 +344,12 @@ if DEBUG and not EMAIL_HOST:
 # ────────────────────────────────────────────────────
 AXES_ENABLED = not DEBUG
 AXES_FAILURE_LIMIT = 5
-AXES_COOLOFF_TIME = 1  # horas
+AXES_COOLOFF_TIME = 1  # hours
 AXES_LOCKOUT_PARAMETERS = ["username", "ip_address"]
 AXES_LOCKOUT_CALLABLE = None
 
 # ────────────────────────────────────────────────────
-# Logging (simples e suficiente)
+# Logging (simple and sufficient)
 # ────────────────────────────────────────────────────
 LOGGING = {
     "version": 1,
@@ -375,7 +374,7 @@ LOGGING = {
 }
 
 # ────────────────────────────────────────────────────
-# Supabase (se precisares no código)
+# Supabase (if needed in code)
 # ────────────────────────────────────────────────────
 SUPABASE_URL = ENV("SUPABASE_URL")
 SUPABASE_KEY = ENV("SUPABASE_KEY")


### PR DESCRIPTION
## Summary
- default session and CSRF cookies to `SameSite=Strict` with env overrides
- document new cookie requirements and integration impact
- add integration test verifying cookies include `SameSite=Strict`
- translate settings comments to English

## Testing
- `DATABASE_URL=sqlite:////tmp/testdb.sqlite3 pytest`
- `pre-commit run --files README.md ourfinancetracker_site/settings.py core/tests/test_cookie_samesite.py` (no hooks to run)


------
https://chatgpt.com/codex/tasks/task_e_68a108696094832ca680d615dcc0de3c