### PR TITLE
Use Django token generator for account activation

### DIFF
--- a/accounts/tests/test_activation_token.py
+++ b/accounts/tests/test_activation_token.py
@@ -1,12 +1,20 @@
 import pytest
 from django.contrib.auth.models import User
-from accounts.tokens import generate_activation_token, validate_activation_token, revoke_activation_token
+from django.utils import timezone
+
+from accounts.tokens import generate_activation_token, validate_activation_token
 
 
 @pytest.mark.django_db
-def test_activation_token_cycle():
-    user = User.objects.create_user(username="u1", password="pw", email="u1@example.com", is_active=False)
+def test_activation_token_invalid_after_login():
+    user = User.objects.create_user(
+        username="u1", password="pw", email="u1@example.com", is_active=False
+    )
     token = generate_activation_token(user)
     assert validate_activation_token(user, token)
-    revoke_activation_token(user)
+
+    # Simulate a login which updates ``last_login`` and invalidates the token.
+    user.last_login = timezone.now()
+    user.save(update_fields=["last_login"])
+
     assert not validate_activation_token(user, token)

--- a/accounts/tokens.py
+++ b/accounts/tokens.py
@@ -1,31 +1,25 @@
-import hashlib
-import secrets
-from django.core.cache import cache
-from django.conf import settings
+"""Activation token utilities.
+
+This module wraps Django's ``PasswordResetTokenGenerator`` for generating
+and validating account activation links. The generator uses user state and a
+timestamp to create time-sensitive tokens without needing any server-side
+storage.
+"""
+
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
 
 
-def _cache_key(user_id: int) -> str:
-    return f"activation:{user_id}"
+_activation_token_generator = PasswordResetTokenGenerator()
 
 
 def generate_activation_token(user) -> str:
-    """Generate a secure activation token for ``user`` and store its hash."""
-    token = secrets.token_urlsafe(32)
-    token_hash = hashlib.sha256(token.encode()).hexdigest()
-    timeout = int(getattr(settings, "ACCOUNT_ACTIVATION_TOKEN_EXPIRATION_SECONDS", 900))
-    cache.set(_cache_key(user.pk), token_hash, timeout)
-    return token
+    """Return a time-sensitive activation token for ``user``."""
+
+    return _activation_token_generator.make_token(user)
 
 
 def validate_activation_token(user, token: str) -> bool:
-    """Check whether ``token`` matches the stored hash for ``user``."""
-    token_hash = cache.get(_cache_key(user.pk))
-    if not token_hash:
-        return False
-    candidate = hashlib.sha256(token.encode()).hexdigest()
-    return secrets.compare_digest(token_hash, candidate)
+    """Validate ``token`` for ``user`` using Django's built-in generator."""
 
+    return _activation_token_generator.check_token(user, token)
 
-def revoke_activation_token(user) -> None:
-    """Manually revoke ``user``'s activation token."""
-    cache.delete(_cache_key(user.pk))

--- a/core/utils/email_helpers.py
+++ b/core/utils/email_helpers.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
-from accounts.tokens import generate_activation_token, revoke_activation_token
+from accounts.tokens import generate_activation_token
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +98,6 @@ def send_account_activation_email(user, request):
         logger.info("Activation email sent to %s", user.email)
         return True
     except (smtplib.SMTPException, BadHeaderError) as exc:
-        revoke_activation_token(user)
         logger.error("Failed to send activation email to %s: %s", user.email, exc)
         return False
 


### PR DESCRIPTION
## Summary
- replace cache-based activation tokens with Django's `PasswordResetTokenGenerator`
- build activation links with the native generator in signup flow and email helpers
- validate activation links using the same generator and adjust tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a10d3c73e0832c86643df3201baac9