### PR TITLE
Improve mobile table responsiveness

### DIFF
--- a/core/static/css/main.css
+++ b/core/static/css/main.css
@@ -697,7 +697,9 @@ button:hover,
   .table-responsive {
     font-size: 0.8rem;
     border-radius: 8px;
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
   }
 
   .table th,

--- a/core/templates/core/recurringtransaction_list.html
+++ b/core/templates/core/recurringtransaction_list.html
@@ -1,21 +1,23 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Recurring Transactions</h1>
-<table class="table">
-  <tr><th>Schedule</th><th>Amount</th><th>Next run</th><th></th></tr>
-  {% for obj in object_list %}
-  <tr>
-    <td>{{ obj.get_schedule_display }}</td>
-    <td>{{ obj.amount }}</td>
-    <td>{{ obj.next_run_at }}</td>
-    <td>
-      <a href="{% url 'recurring_update' obj.pk %}">Edit</a>
-      <a href="{% url 'recurring_delete' obj.pk %}">Delete</a>
-    </td>
-  </tr>
-  {% empty %}
-  <tr><td colspan="4">No recurring transactions.</td></tr>
-  {% endfor %}
-</table>
+<div class="table-responsive">
+  <table class="table table-hover mb-0">
+    <tr><th>Schedule</th><th>Amount</th><th>Next run</th><th></th></tr>
+    {% for obj in object_list %}
+    <tr>
+      <td>{{ obj.get_schedule_display }}</td>
+      <td>{{ obj.amount }}</td>
+      <td>{{ obj.next_run_at }}</td>
+      <td>
+        <a href="{% url 'recurring_update' obj.pk %}">Edit</a>
+        <a href="{% url 'recurring_delete' obj.pk %}">Delete</a>
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="4">No recurring transactions.</td></tr>
+    {% endfor %}
+  </table>
+</div>
 <a href="{% url 'recurring_create' %}">Add new</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable horizontal scrolling for tables on mobile
- wrap recurring transactions table in responsive container

## Testing
- `pytest`
- `pre-commit run --hook-stage push --files core/static/css/main.css core/templates/core/recurringtransaction_list.html`


------
https://chatgpt.com/codex/tasks/task_e_68a131c06e44832caeee43f63dbec7b9