### PR TITLE
fix: load mobile transaction grouping script

### DIFF
--- a/core/templates/core/transaction_list_v2.html
+++ b/core/templates/core/transaction_list_v2.html
@@ -462,6 +462,6 @@
 />
 
 <!-- Custom JavaScript -->
-<script src="{% static 'js/transaction_list_ajax.js' %}" nonce="{{ request.csp_nonce }}"></script>
+<script src="{% static 'js/transaction_list_v2.js' %}" nonce="{{ request.csp_nonce }}"></script>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- load mobile grouping script to enable category/month/account grouping on transaction lists

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a137ae71d0832ca704c5bae5c72f87