### PR TITLE
Fix jQuery loading for transaction list

### DIFF
--- a/core/templates/core/transaction_list_v2.html
+++ b/core/templates/core/transaction_list_v2.html
@@ -462,6 +462,6 @@
 />
 
 <!-- Custom JavaScript -->
-<script src="{% static 'js/transaction_list_v2.js' %}" nonce="{{ request.csp_nonce }}"></script>
+<script src="{% static 'js/transaction_list_v2.js' %}" defer nonce="{{ request.csp_nonce }}"></script>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- defer transaction_list_v2.js so it executes after jQuery is loaded, preventing `$ is not defined` errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a13a39ca6c832cb4d99b2e2a623577