### PR TITLE
Add ETag and Last-Modified headers to transaction APIs

### DIFF
--- a/core/tests/test_etag_headers.py
+++ b/core/tests/test_etag_headers.py
@@ -1,0 +1,57 @@
+import json
+from decimal import Decimal
+from datetime import date
+
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from core.models import Transaction
+
+
+class ETagHeadersTest(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user("etaguser", "etag@example.com", "pass")
+        self.client.force_login(self.user)
+        Transaction.objects.create(user=self.user, date=date(2024, 1, 1), amount=Decimal("10.00"), type="IN")
+
+    def test_transactions_json_etag(self):
+        url = reverse("transactions_json")
+        params = {"date_start": "2024-01-01", "date_end": "2024-12-31"}
+        response = self.client.get(url, params)
+        self.assertIn("ETag", response)
+        self.assertIn("Last-Modified", response)
+        etag = response["ETag"]
+        last_mod = response["Last-Modified"]
+        response_304 = self.client.get(url, params, HTTP_IF_NONE_MATCH=etag)
+        self.assertEqual(response_304.status_code, 304)
+        response_304_lm = self.client.get(url, params, HTTP_IF_MODIFIED_SINCE=last_mod)
+        self.assertEqual(response_304_lm.status_code, 304)
+
+    def test_transactions_totals_v2_etag(self):
+        url = reverse("transactions_totals_v2")
+        payload = {
+            "date_start": "2024-01-01",
+            "date_end": "2024-12-31",
+            "include_system": False,
+        }
+        response = self.client.post(url, data=json.dumps(payload), content_type="application/json")
+        self.assertIn("ETag", response)
+        self.assertIn("Last-Modified", response)
+        etag = response["ETag"]
+        last_mod = response["Last-Modified"]
+        response_304 = self.client.post(
+            url,
+            data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_IF_NONE_MATCH=etag,
+        )
+        self.assertEqual(response_304.status_code, 304)
+        response_304_lm = self.client.post(
+            url,
+            data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_IF_MODIFIED_SINCE=last_mod,
+        )
+        self.assertEqual(response_304_lm.status_code, 304)

--- a/core/views.py
+++ b/core/views.py
@@ -32,7 +32,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import connection, models, transaction as db_transaction, IntegrityError
-from django.db.models import Q, Sum
+from django.db.models import Q, Sum, Max
 from django.db.models.query import QuerySet
 from django.http import (
     Http404,
@@ -43,6 +43,7 @@ from django.http import (
 from django.shortcuts import get_object_or_404, render, redirect
 from django.urls import reverse, reverse_lazy
 from django.utils.timezone import now
+from django.utils.http import http_date, parse_http_date_safe
 from django.views import View
 from django.views.decorators.http import require_GET, require_POST, require_http_methods
 from django.views.generic import (
@@ -797,10 +798,15 @@ def transactions_json(request):
         return JsonResponse({"error": "Invalid date format"}, status=400)
 
     cache_key = _cache_key(user_id, start_date, end_date)
-    cached_df = cache.get(cache_key)
+    cached = cache.get(cache_key)
 
-    if cached_df is not None:
-        df = cached_df.copy()
+    if cached is not None:
+        if isinstance(cached, dict):
+            df = cached["df"].copy()
+            last_modified = cached.get("last_modified", now())
+        else:
+            df = cached.copy()
+            last_modified = now()
     else:
         with connection.cursor() as cursor:
             cursor.execute("""
@@ -827,7 +833,10 @@ def transactions_json(request):
             "id", "date", "year", "month", "type", "amount",
             "category", "account", "currency", "tags"
         ])
-        cache.set(cache_key, df.copy(), timeout=300)
+        last_modified = Transaction.objects.filter(
+            user_id=user_id, date__range=(start_date, end_date)
+        ).aggregate(Max("updated_at"))['updated_at__max'] or now()
+        cache.set(cache_key, {"df": df.copy(), "last_modified": last_modified}, timeout=300)
 
     # Transformações e formatação
     df["date"] = df["date"].astype(str)
@@ -983,7 +992,7 @@ def transactions_json(request):
     length = int(request.GET.get("length", 10))
     page_df = df.iloc[start : start + length]
 
-    return JsonResponse({
+    response_data = {
         "draw": draw,
         "recordsTotal": len(df),
         "recordsFiltered": len(df),
@@ -994,7 +1003,24 @@ def transactions_json(request):
             "accounts": available_accounts,
             "periods": available_periods,
         },
-    })
+    }
+
+    response_json = json.dumps(response_data, sort_keys=True)
+    etag = hashlib.md5(response_json.encode("utf-8")).hexdigest()
+
+    if request.headers.get("If-None-Match") == etag:
+        return HttpResponse(status=304)
+
+    ims = request.headers.get("If-Modified-Since")
+    if ims:
+        ims_ts = parse_http_date_safe(ims)
+        if ims_ts is not None and int(last_modified.timestamp()) <= ims_ts:
+            return HttpResponse(status=304)
+
+    response = JsonResponse(response_data)
+    response["ETag"] = etag
+    response["Last-Modified"] = http_date(last_modified.timestamp())
+    return response
 
 
 
@@ -2135,7 +2161,7 @@ def transactions_totals_v2(request):
     with connection.cursor() as cursor:
         # Simplified query to avoid duplication from tag JOINs
         query = f"""
-            SELECT 
+            SELECT
                 tx.type,
                 SUM(tx.amount) as total
             FROM core_transaction tx
@@ -2149,6 +2175,20 @@ def transactions_totals_v2(request):
         logger.debug(f"📝 [transactions_totals_v2] SQL Query: {query}")
         cursor.execute(query, params)
         rows = cursor.fetchall()
+        cursor.execute(
+            f"""
+            SELECT MAX(tx.updated_at)
+            FROM core_transaction tx
+            LEFT JOIN core_category cat ON tx.category_id = cat.id
+            LEFT JOIN core_account acc ON tx.account_id = acc.id
+            LEFT JOIN core_dateperiod dp ON tx.period_id = dp.id
+            WHERE {where_clause}
+            """,
+            params,
+        )
+        last_modified = cursor.fetchone()[0] or now()
+        if isinstance(last_modified, str):
+            last_modified = datetime.fromisoformat(last_modified)
 
     logger.debug(f"📊 [transactions_totals_v2] Raw results: {rows}")
 
@@ -2203,7 +2243,22 @@ def transactions_totals_v2(request):
     # Convert Decimals to floats rounded to 2 decimal places for JSON serialization
     totals = {k: float(v.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)) for k, v in totals.items()}
 
-    return JsonResponse(totals)
+    response_json = json.dumps(totals, sort_keys=True)
+    etag = hashlib.md5(response_json.encode("utf-8")).hexdigest()
+
+    if request.headers.get("If-None-Match") == etag:
+        return HttpResponse(status=304)
+
+    ims = request.headers.get("If-Modified-Since")
+    if ims:
+        ims_ts = parse_http_date_safe(ims)
+        if ims_ts is not None and int(last_modified.timestamp()) <= ims_ts:
+            return HttpResponse(status=304)
+
+    response = JsonResponse(totals)
+    response["ETag"] = etag
+    response["Last-Modified"] = http_date(last_modified.timestamp())
+    return response
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
- Add ETag and Last-Modified caching to `transactions_json` and `transactions_totals_v2` views
- Store last-modified timestamps with cached transaction data
- Test conditional GET support for both endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a13961f6c0832caa78cebfb3a91bde