### PR TITLE
Add Sentry error monitoring

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+
+
+def sentry_dsn(request):
+    """Expose SENTRY_DSN so templates can initialize Sentry browser SDK."""
+    return {"SENTRY_DSN": getattr(settings, "SENTRY_DSN", "")}

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -187,6 +187,16 @@
     <script nonce="{{ request.csp_nonce }}">
       window.CSP_NONCE = "{{ request.csp_nonce }}";
     </script>
+    {% if SENTRY_DSN %}
+    <script src="https://browser.sentry-cdn.com/7.114.0/bundle.tracing.min.js" crossorigin="anonymous"></script>
+    <script nonce="{{ request.csp_nonce }}">
+      Sentry.init({
+        dsn: "{{ SENTRY_DSN }}",
+        sampleRate: 0.1,
+        tracesSampleRate: 0.0,
+      });
+    </script>
+    {% endif %}
 </head>
 <body class="bg-light">
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,9 @@ pytz==2025.2
 # Structured logging
 django-structlog==9.1.1
 
+# Error monitoring
+sentry-sdk==2.19.2
+
 # Backup utilities
 django-dbbackup==4.3.0
 


### PR DESCRIPTION
## Summary
- integrate Sentry SDK for Django with low sampling
- capture browser errors via Sentry script
- permit Sentry domains in CSP and expose DSN via context processor

## Testing
- `pre-commit run --files requirements.txt ourfinancetracker_site/settings.py core/templates/base.html core/context_processors.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1415a0eac832c8da2a53de834adce