### PR TITLE
Log N+1 queries in PerformanceMiddleware

### DIFF
--- a/core/middleware/performance.py
+++ b/core/middleware/performance.py
@@ -1,10 +1,21 @@
 
 import logging
+import re
 import time
+
 from django.db import connection
 from django.utils.deprecation import MiddlewareMixin
 
-logger = logging.getLogger('core.performance')
+logger = logging.getLogger("core.performance")
+
+
+def _normalize_sql(sql: str) -> str:
+    """Normalize SQL by removing literal values to find N+1 patterns."""
+    # Replace quoted strings
+    sql = re.sub(r"'[^']*'", "?", sql)
+    # Replace numbers
+    sql = re.sub(r"\b\d+\b", "?", sql)
+    return sql
 
 class PerformanceMiddleware(MiddlewareMixin):
     """Middleware para monitorizar performance das requests"""
@@ -31,6 +42,19 @@ class PerformanceMiddleware(MiddlewareMixin):
                     f"High DB usage: {request.method} {request.path} "
                     f"used {db_queries} queries in {duration:.2f}s"
                 )
+
+            # Detetar e registar possíveis N+1 queries
+            queries = connection.queries[getattr(request, 'db_queries_start', 0):]
+            normalized = {}
+            for q in queries:
+                sql = q.get("sql", "")
+                norm = _normalize_sql(sql)
+                normalized[norm] = normalized.get(norm, 0) + 1
+            for sql, count in normalized.items():
+                if count > 1:
+                    logger.warning(
+                        f"Potential N+1 query detected {count} times: {sql[:200]}"
+                    )
             
             # Adicionar headers de performance em desenvolvimento
             if hasattr(request, 'user') and request.user.is_staff:

--- a/core/tests/test_performance_middleware.py
+++ b/core/tests/test_performance_middleware.py
@@ -1,0 +1,34 @@
+import logging
+
+from django.http import HttpResponse
+from django.test import override_settings
+from django.urls import path
+from django.conf import settings
+
+from core.models import Currency
+
+
+def nplus_one_view(request):
+    ids = list(Currency.objects.values_list("id", flat=True))
+    for i in ids:
+        Currency.objects.get(id=i)
+    return HttpResponse("ok")
+
+
+urlpatterns = [path("nplus/", nplus_one_view)]
+
+
+@override_settings(
+    DEBUG=True,
+    ROOT_URLCONF=__name__,
+    MIDDLEWARE=[*settings.MIDDLEWARE, "core.middleware.performance.PerformanceMiddleware"],
+)
+def test_nplus_one_logging(client, caplog, db):
+    Currency.objects.create(code="AAA")
+    Currency.objects.create(code="BBB")
+
+    with caplog.at_level(logging.WARNING, logger="core.performance"):
+        response = client.get("/nplus/")
+        assert response.status_code == 200
+
+    assert any("N+1" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- detect repetitive SQL patterns and warn about potential N+1 queries
- add regression test ensuring middleware logs N+1 warning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a141647bf0832c8e5fe1fc6faa0877