### PR TITLE
fix: avoid inline style in transaction form

### DIFF
--- a/core/static/js/transaction_form.js
+++ b/core/static/js/transaction_form.js
@@ -218,7 +218,7 @@ function initTransactionForm() {
   if (flowDiv && typeRadios.length) {
     function toggleFlow() {
       const selected = document.querySelector('input[name="type"]:checked');
-      flowDiv.style.display = (selected?.value === "IV") ? "" : "none";
+      flowDiv.classList.toggle("d-none", selected?.value !== "IV");
     }
     typeRadios.forEach(r => r.addEventListener("change", toggleFlow));
     toggleFlow();


### PR DESCRIPTION
## Summary
- toggle investment flow via CSS class instead of inline style

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a14434a94c832c906334b5b3f96b9d