### PR TITLE
Restore dynamic investment flow in transaction form

### DIFF
--- a/core/static/js/transaction_form.js
+++ b/core/static/js/transaction_form.js
@@ -227,12 +227,18 @@ function initTransactionForm() {
   }
 
   const flowDiv = document.getElementById("investment-flow");
+  const typeSelect = document.getElementById("id_type");
   const typeRadios = document.querySelectorAll('input[name="type"]');
-  if (flowDiv && typeRadios.length) {
-    function toggleFlow() {
+  if (flowDiv) {
+    const getTypeValue = () => {
+      if (typeSelect) return typeSelect.value;
       const selected = document.querySelector('input[name="type"]:checked');
-      flowDiv.classList.toggle("d-none", selected?.value !== "IV");
+      return selected ? selected.value : null;
+    };
+    function toggleFlow() {
+      flowDiv.classList.toggle("d-none", getTypeValue() !== "IV");
     }
+    typeSelect?.addEventListener("change", toggleFlow);
     typeRadios.forEach(r => r.addEventListener("change", toggleFlow));
     toggleFlow();
   }

--- a/core/templates/core/transaction_form.html
+++ b/core/templates/core/transaction_form.html
@@ -80,16 +80,17 @@
 
         <!-- INVESTMENT FLOW -->
         <div class="mb-3 d-none" id="investment-flow">
-          <label class="form-label">Investment Flow</label>
+          <label class="form-label">{{ form.direction.label }}</label>
           <div class="btn-group w-100" role="group">
-            <input type="radio" class="btn-check" name="direction" id="dir_in" value="IN"
-                   {% if form.initial.direction != "OUT" %}checked{% endif %}>
+            <input type="radio" class="btn-check" name="{{ form.direction.name }}" id="dir_in" value="IN"
+                   {% if form.direction.value != "OUT" %}checked{% endif %}>
             <label class="btn btn-outline-success" for="dir_in">Reinforcement</label>
 
-            <input type="radio" class="btn-check" name="direction" id="dir_out" value="OUT"
-                   {% if form.initial.direction == "OUT" %}checked{% endif %}>
+            <input type="radio" class="btn-check" name="{{ form.direction.name }}" id="dir_out" value="OUT"
+                   {% if form.direction.value == "OUT" %}checked{% endif %}>
             <label class="btn btn-outline-danger" for="dir_out">Withdrawal</label>
           </div>
+          {% if form.direction.errors %}<div class="text-danger small">{{ form.direction.errors.0 }}</div>{% endif %}
         </div>
 
         <!-- CATEGORY -->

--- a/core/tests/test_transaction_form.py
+++ b/core/tests/test_transaction_form.py
@@ -55,6 +55,39 @@ def test_direction_applies_sign_for_investment():
 
 
 @pytest.mark.django_db
+def test_investment_requires_direction():
+    user = User.objects.create_user('u7')
+    data = {
+        'date': '2024-01-10',
+        'type': Transaction.Type.INVESTMENT,
+        'amount': '100',
+        'period': '2024-01',
+        'category': 'Invest',
+    }
+    form = TransactionForm(data=data, user=user)
+    assert not form.is_valid()
+    assert 'direction' in form.errors
+
+
+@pytest.mark.django_db
+def test_edit_form_preselects_direction():
+    user = User.objects.create_user('u8')
+    data = {
+        'date': '2024-01-10',
+        'type': Transaction.Type.INVESTMENT,
+        'amount': '50',
+        'direction': 'OUT',
+        'period': '2024-01',
+        'category': 'Invest',
+    }
+    form = TransactionForm(data=data, user=user)
+    assert form.is_valid(), form.errors
+    tx = form.save()
+    edit_form = TransactionForm(user=user, instance=tx)
+    assert edit_form['direction'].value() == 'OUT'
+
+
+@pytest.mark.django_db
 def test_invalid_and_valid_period():
     user = User.objects.create_user('u5')
     data = {


### PR DESCRIPTION
## Summary
- reinstate investment flow radio block and client-side toggle
- enforce direction choice for investment transactions and adjust amount sign
- add tests for investment flow validation and editing behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a14d224658832c80720e975cb1b16d