### PR TITLE
Adjust balance template example

### DIFF
--- a/core/tests/test_import_export.py
+++ b/core/tests/test_import_export.py
@@ -84,9 +84,9 @@ def test_account_balance_import_and_template(client):
     file = SimpleUploadedFile('balances.xlsx', output.read(), content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
     client.post(reverse('account_balance_import_xlsx'), {'file': file}, follow=True)
     assert AccountBalance.objects.filter(account__user=user, reported_balance=Decimal('100')).exists()
-    response = client.get(reverse('account_balance_template_xlsx'))
+    response = client.get(reverse("account_balance_template_xlsx"))
     wb = pd.read_excel(BytesIO(response.content))
-    assert 'Savings' in wb['Account'].tolist()
+    assert "Bpi" in wb["Account"].tolist()
 
 @pytest.mark.django_db
 def test_account_balance_import_missing_columns(client):

--- a/core/views.py
+++ b/core/views.py
@@ -3188,12 +3188,12 @@ def account_balance_import_xlsx(request):
 
 @login_required
 def account_balance_template_xlsx(request):
-    """Download template for account balance import using Savings and Investments accounts."""
+    """Download template for account balance import with a single example row."""
     data = {
-        'Year': [2025, 2025],
-        'Month': [1, 1],
-        'Account': ['Savings', 'Investments'],
-        'Balance': [1000.00, 5000.00]
+        "Year": [2025],
+        "Month": [6],
+        "Account": ["Bpi"],
+        "Balance": [1234.56],
     }
     df = pd.DataFrame(data)
 


### PR DESCRIPTION
## Summary
- Update account balance template to provide one sample row (2025-06, Bpi, 1234.56)
- Adapt import/export test to expect the new example account

## Testing
- `pre-commit run --files core/views.py core/tests/test_import_export.py` *(fails: E501 line too long, F401 unused imports)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a14374f52c832c87853ce80184751f