### PR TITLE
Add edit/delete actions column for transactions

### DIFF
--- a/core/static/js/transaction_list_ajax.js
+++ b/core/static/js/transaction_list_ajax.js
@@ -17,6 +17,10 @@
         if (n) {
             script.setAttribute('nonce', n);
         }
+        // Log when the full implementation is ready (includes actions column)
+        script.onload = function() {
+            console.log('transaction_list_v2.js loaded with actions column support');
+        };
         document.body.appendChild(script);
     }
 })();

--- a/core/views.py
+++ b/core/views.py
@@ -993,14 +993,15 @@ def transactions_json(request):
         axis=1
     )
 
-    # ✅ CORREÇÃO: criar ações como string HTML
+    # ✅ CORREÇÃO: criar ações como string HTML com ícones e texto
     df["actions"] = df.apply(
-        lambda r: f"""
-        <div class='btn-group'>
-          <a href='/transactions/{r["id"]}/edit/' class='btn btn-sm btn-outline-primary'>✏️</a>
-          <a href='/transactions/{r["id"]}/delete/' class='btn btn-sm btn-outline-danger'>🗑️</a>
-        </div>
-        """, axis=1
+        lambda r: (
+            f"<div class='btn-group'>"
+            f"<a href='/transactions/{r['id']}/edit/' class='btn btn-sm btn-outline-primary'>✏️ Edit</a>"
+            f"<a href='/transactions/{r['id']}/delete/' class='btn btn-sm btn-outline-danger'>🗑️ Delete</a>"
+            f"</div>"
+        ),
+        axis=1
     )
 
     # Paginação (DataTables)


### PR DESCRIPTION
## Summary
- include HTML "✏️ Edit" and "🗑️ Delete" buttons in `transactions_json` API
- note actions column when loading legacy `transaction_list_ajax.js` shim

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a143881774832c9bebc53d5ef1ef39