### PR TITLE
Default investment flow to withdrawal

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -154,7 +154,8 @@ class TransactionForm(forms.ModelForm):
             if "amount" not in self.initial and not self.data:
                 self.initial["amount"] = ""
 
-        self.fields["direction"].initial = self.initial.get("direction", "IN")
+        # Default investment flow to "Withdrawal" so users explicitly opt-in to reinforcement
+        self.fields["direction"].initial = self.initial.get("direction", "OUT")
 
     def clean_amount(self) -> Decimal:
         raw = (self.data.get("amount") or "").strip()


### PR DESCRIPTION
## Summary
- default investment flow to Withdrawal so users explicitly choose Reinforcement

## Testing
- `pre-commit run --files core/forms.py` *(fails: F401 unused import, E501 line too long)*
- `pytest core/tests/test_transaction_form.py::test_direction_applies_sign_for_investment -q`
- `pytest core/tests/test_transaction_form.py::test_investment_requires_direction -q`


------
https://chatgpt.com/codex/tasks/task_e_68a152c0cbf0832cb58db37981888429