### PR TITLE
Allow inline style attributes via CSP

### DIFF
--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -284,6 +284,9 @@ CONTENT_SECURITY_POLICY = {
             "https://cdnjs.cloudflare.com",
             "https://code.jquery.com",
         ),
+        "style-src-attr": (
+            "'unsafe-inline'",
+        ),
         "img-src": ("'self'", "data:"),
         "connect-src": ("'self'", "https://*.ingest.sentry.io"),
         "font-src": (


### PR DESCRIPTION
## Summary
- permit inline style attributes through CSP `style-src-attr 'unsafe-inline'`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a154dac95c832c8d8451d01b6af3ed