### PR TITLE
Ensure tests run by setting SECRET_KEY and remove inline styles

### DIFF
--- a/core/templates/core/account_balance.html
+++ b/core/templates/core/account_balance.html
@@ -16,9 +16,9 @@
               <!-- Month Navigation -->
               <div class="btn-group" role="group">
                 <a class="btn btn-outline-secondary btn-sm" href="?year={{ year }}&month={{ month|add:'-1' }}">‹ Prev</a>
-                <input type="month" id="selector" value="{{ year }}-{{ month|stringformat:'02d' }}" 
+                <input type="month" id="selector" value="{{ year }}-{{ month|stringformat:'02d' }}"
                        onchange="window.location='?month='+this.value.split('-')[1]+'&year='+this.value.split('-')[0];"
-                       class="form-control form-control-sm" style="width: 140px;">
+                       class="form-control form-control-sm w-auto">
                 <a class="btn btn-outline-secondary btn-sm" href="?year={{ year }}&month={{ month|add:'1' }}">Next ›</a>
               </div>
 
@@ -81,18 +81,18 @@
               <table class="table table-hover mb-0">
                 <thead class="table-light">
                   <tr>
-                    <th style="width: 40px;" class="text-center">📱</th>
+                    <th class="text-center">📱</th>
                     <th>Account Name</th>
-                    <th class="text-end" style="width: 180px;">Balance</th>
-                    <th style="width: 60px;" class="text-center">Actions</th>
+                    <th class="text-end">Balance</th>
+                    <th class="text-center">Actions</th>
                   </tr>
                 </thead>
                 <tbody class="sortable-table" data-reorder-url="{% url 'account_reorder' %}"
                        {% if account_type == "Savings" and currency == "EUR" %}id="balance-table"{% endif %}>
                   {% for form in forms %}
                     <tr class="form-row" data-id="{{ form.instance.account.id|default:'' }}" data-account-name="{{ form.instance.account.name|default:'' }}">
-                      <td class="text-center handle" style="cursor: grab;" title="Drag to reorder">
-                        <span style="font-size: 14px; color: #6c757d; user-select: none;">⋮⋮</span>
+                      <td class="text-center handle" title="Drag to reorder">
+                        <span class="handle-icon">⋮⋮</span>
                       </td>
                       <td>
                         {{ form.account.as_hidden }}
@@ -151,7 +151,7 @@
   <!-- New Row Template -->
   <template id="empty-form-template">
     <tr class="form-row">
-      <td class="text-center handle" style="cursor: grab;">⋮⋮</td>
+      <td class="text-center handle"><span class="handle-icon">⋮⋮</span></td>
       <td>
         <select class="form-select account-select"></select>
         <input type="hidden" name="form-__prefix__-account" />
@@ -198,10 +198,10 @@
 
 <!-- Delete Confirmation Modal -->
 <div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-labelledby="deleteConfirmModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered" style="max-width: 400px;">
-    <div class="modal-content" style="border-radius: 8px;">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
       <div class="modal-body text-center py-4">
-        <p class="mb-3" style="font-size: 16px; color: #333;">Are you sure you want to delete this balance?</p>
+        <p class="mb-3 text-dark">Are you sure you want to delete this balance?</p>
         <div class="d-flex justify-content-center gap-3">
           <button type="button" class="btn btn-primary px-4" id="confirm-delete-btn">OK</button>
           <button type="button" class="btn btn-secondary px-3" data-bs-dismiss="modal">Cancel</button>

--- a/core/templates/core/transaction_form.html
+++ b/core/templates/core/transaction_form.html
@@ -79,7 +79,7 @@
         </div>
 
         <!-- INVESTMENT FLOW -->
-        <div class="mb-3" id="investment-flow" style="display:none;">
+        <div class="mb-3 d-none" id="investment-flow">
           <label class="form-label">Investment Flow</label>
           <div class="btn-group w-100" role="group">
             <input type="radio" class="btn-check" name="direction" id="dir_in" value="IN"

--- a/ourfinancetracker_site/settings_test.py
+++ b/ourfinancetracker_site/settings_test.py
@@ -1,3 +1,9 @@
+import os
+
+# Provide a deterministic secret key so tests can run without requiring an
+# external environment configuration.  This key is suitable only for tests.
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+
 from .settings import *  # inherit base settings
 
 # --- Database: SQLite for tests (no Supabase, no Pooler) ---


### PR DESCRIPTION
## Summary
- Provide a deterministic `SECRET_KEY` in `settings_test` so tests run without environment configuration
- Replace inline `style` attributes with Bootstrap classes and semantic markup in HTML templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1568a415c832c8ae13c41b62ebba5