### PR TITLE
Fix investment flow toggle display

### DIFF
--- a/core/templates/core/transaction_form.html
+++ b/core/templates/core/transaction_form.html
@@ -5,7 +5,7 @@
 
 {% block title %}
 {% if form.instance.pk %}Edit Transaction{% else %}New Transaction{% endif %} - OurFinanceTracker
-{% endblock %}
+{% endblock title %}
 
 {% block content %}
 <div class="container mt-4">
@@ -79,7 +79,7 @@
         </div>
 
         <!-- INVESTMENT FLOW -->
-        <div class="mb-3" id="investment-flow" style="display:none;">
+        <div class="mb-3 d-none" id="investment-flow">
           <label class="form-label">Investment Flow</label>
           <div class="btn-group w-100" role="group">
             <input type="radio" class="btn-check" name="direction" id="dir_in" value="IN"
@@ -149,4 +149,4 @@
 <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <script src="https://cdn.jsdelivr.net/npm/tom-select/dist/js/tom-select.complete.min.js"></script>
 <script src="{% static 'js/transaction_form.js' %}"></script>
-{% endblock %}
+{% endblock content %}


### PR DESCRIPTION
## Summary
- remove inline style from investment-flow div and use Bootstrap `d-none` class
- name template blocks to satisfy linting

## Testing
- `pre-commit run --files core/templates/core/transaction_form.html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a158c7bb54832cb7d84fd9cdde0a4c