### PR TITLE
fix tooltip initialization for null elements

### DIFF
--- a/core/static/js/dashboard.js
+++ b/core/static/js/dashboard.js
@@ -1023,16 +1023,22 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     // Reinitialize tooltips for updated elements
-    const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
-    tooltipTriggerList.forEach(el => {
-      // Dispose existing tooltip if any
-      const existingTooltip = bootstrap.Tooltip.getInstance(el);
-      if (existingTooltip) {
-        existingTooltip.dispose();
-      }
-      // Create new tooltip
-      new bootstrap.Tooltip(el);
-    });
+    const tooltipTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+    tooltipTriggerList
+      .filter(el => el && (el.getAttribute('title') || el.getAttribute('data-bs-original-title')))
+      .forEach(el => {
+        // Dispose existing tooltip if any
+        const existingTooltip = bootstrap.Tooltip.getInstance(el);
+        if (existingTooltip) {
+          existingTooltip.dispose();
+        }
+        try {
+          // Create new tooltip
+          new bootstrap.Tooltip(el);
+        } catch (err) {
+          console.error('Tooltip initialization failed', err, el);
+        }
+      });
 
     if (window.recomputeKPICards) {
       window.recomputeKPICards();

--- a/core/static/js/main.js
+++ b/core/static/js/main.js
@@ -10,10 +10,16 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // ───── Bootstrap tooltips ─────
-  const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
-  tooltipTriggerList.forEach(el => {
-    new bootstrap.Tooltip(el);
-  });
+  const tooltipTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+  tooltipTriggerList
+    .filter(el => el && (el.getAttribute('title') || el.getAttribute('data-bs-original-title')))
+    .forEach(el => {
+      try {
+        new bootstrap.Tooltip(el);
+      } catch (err) {
+        console.error('Tooltip initialization failed', err, el);
+      }
+    });
 
   // ───── Bootstrap popovers (opcional) ─────
   const popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'));


### PR DESCRIPTION
## Summary
- guard tooltip initialization against missing tooltip attributes
- safely reinitialize dashboard tooltips and log failures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a15b730590832cb779c65a325d4a8a