### PR TITLE
Relax CSP inline style handling

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -105,7 +105,9 @@ class TransactionForm(forms.ModelForm):
                 "placeholder": "0.00",
                 "id": "id_amount",
             }),
-            "notes": forms.Textarea(attrs={"class": "form-control", "rows": "3", "style": "height:5em;"}),
+            "notes": forms.Textarea(
+                attrs={"class": "form-control notes-textarea", "rows": "3"}
+            ),
         }
 
     def __init__(self, *args, user: User = None, **kwargs):

--- a/core/static/css/main.css
+++ b/core/static/css/main.css
@@ -1197,6 +1197,7 @@ button:hover,
 .p-075 { padding: 0.75rem; }
 
 /* Utility classes to replace inline styles */
+.notes-textarea { height: 5em; }
 .w-30 { width: 30px; }
 .w-40 { width: 40px; }
 .w-60 { width: 60px; }

--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -279,13 +279,11 @@ CONTENT_SECURITY_POLICY = {
         "style-src": (
             "'self'",
             NONCE,
+            "'unsafe-inline'",
             "https://cdn.jsdelivr.net",
             "https://cdn.datatables.net",
             "https://cdnjs.cloudflare.com",
             "https://code.jquery.com",
-        ),
-        "style-src-attr": (
-            "'unsafe-inline'",
         ),
         "img-src": ("'self'", "data:"),
         "connect-src": ("'self'", "https://*.ingest.sentry.io"),


### PR DESCRIPTION
## Summary
- allow inline styles with unsafe-inline in CSP style-src
- move transaction notes height styling into CSS utility class

## Testing
- `pre-commit run --files ourfinancetracker_site/settings.py core/forms.py core/static/css/main.css` *(fails: flake8 line-length warnings in unrelated code)*
- `SKIP=flake8,black,isort pre-commit run --files ourfinancetracker_site/settings.py core/forms.py core/static/css/main.css`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a15b8e4f94832cadd8a42b1d6c7ac1