### PR TITLE
Show average investment in dashboard

### DIFF
--- a/core/static/js/dashboard.js
+++ b/core/static/js/dashboard.js
@@ -841,11 +841,12 @@ document.addEventListener("DOMContentLoaded", () => {
       const estimatedExpenses = Math.max(200, estimatedIncome * 0.3); // Conservative estimate
       const savingsRate = estimatedIncome > 0 ? ((estimatedIncome - estimatedExpenses) / estimatedIncome * 100) : 0;
 
+      const months = Math.max(allPeriods.length, 1);
       return {
         patrimonio_total: `${totalPatrimonio.toLocaleString('en-GB')} €`,
         receita_media: `${Math.round(estimatedIncome).toLocaleString('en-GB')} €`,
         despesa_estimada_media: `${Math.round(estimatedExpenses).toLocaleString('en-GB')} €`,
-        valor_investido_total: `${totalInvestments.toLocaleString('en-GB')} €`,
+        valor_investido_medio: `${Math.round(totalInvestments / months).toLocaleString('en-GB')} €`,
         despesas_justificadas_pct: "95%", // Optimistic estimate
         taxa_poupanca: `${savingsRate.toFixed(1)}%`,
         wealth_growth: `${wealthGrowth >= 0 ? '+' : ''}${wealthGrowth.toFixed(1)}%`,
@@ -863,7 +864,7 @@ document.addEventListener("DOMContentLoaded", () => {
       patrimonio_total: "12,500 €",
       receita_media: "2,500 €",
       despesa_estimada_media: "1,800 €",
-      valor_investido_total: "8,500 €",
+      valor_investido_medio: "8,500 €",
       despesas_justificadas_pct: "85%",
       rentabilidade_mensal_media: "+2.5%",
       status: 'mock_data'
@@ -986,7 +987,7 @@ document.addEventListener("DOMContentLoaded", () => {
       'receita-media': data.receita_media || data.patrimonio_total || '0 €',
       'despesa-estimada': data.despesa_estimada_media || data.receita_media || '0 €',
       'verified-expenses': data.despesas_justificadas_pct_str || '0%',
-      'valor-investido': data.valor_investido_total || '0 €',
+      'valor-investido': data.valor_investido_medio || '0 €',
       'patrimonio-total': data.patrimonio_total || '0 €'
     };
 
@@ -1050,7 +1051,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const generateKPITooltip = (id, value, data) => {
     const receita = parseFloat((data.receita_media || '0').replace(/[^\d.-]/g, '')) || 0;
     const despesa = parseFloat((data.despesa_estimada_media || '0').replace(/[^\d.-]/g, '')) || 0;
-    const investido = parseFloat((data.valor_investido_total || '0').replace(/[^\d.-]/g, '')) || 0;
+    const investido = parseFloat((data.valor_investido_medio || '0').replace(/[^\d.-]/g, '')) || 0;
     const patrimonio = parseFloat((data.patrimonio_total || '0').replace(/[^\d.-]/g, '')) || 0;
 
     switch(id) {
@@ -1084,13 +1085,13 @@ document.addEventListener("DOMContentLoaded", () => {
           </div>
         `;
       case 'valor-investido':
-        const investmentRatio = patrimonio > 0 ? (investido / patrimonio * 100).toFixed(1) : 0;
+        const investmentRatio = receita > 0 ? (investido / receita * 100).toFixed(1) : 0;
         return `
           <div class="text-start">
-            <strong>📈 Total Invested</strong><br>
+            <strong>📈 Average Investement</strong><br>
             Amount: <span class="text-primary">${value}</span><br>
-            <small>📊 ${investmentRatio}% of net worth</small><br>
-            <small>💡 ${investmentRatio > 60 ? 'High growth focus' : investmentRatio > 30 ? 'Balanced approach' : 'Conservative strategy'}</small>
+            <small>📊 ${investmentRatio}% of income</small><br>
+            <small>💡 ${investmentRatio > 20 ? 'Strong investing habit' : investmentRatio > 10 ? 'Good progress' : 'Could invest more'}</small>
           </div>
         `;
       case 'patrimonio-total':

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -914,9 +914,9 @@ Dashboard{% endblock %} {% block extra_head %}
         <div class="card-body text-center p-3">
           <div class="d-flex justify-content-between align-items-center">
             <div>
-              <h6 class="card-title kpi-title text-info mb-1">📈 Invested Amount</h6>
+              <h6 class="card-title kpi-title text-info mb-1">📈 Average Investement</h6>
               <h4 class="card-text kpi-value mb-0" id="valor-investido">€ 0</h4>
-              <small class="text-muted kpi-subtitle">Total</small>
+              <small class="text-muted kpi-subtitle">Monthly Avg</small>
             </div>
             <button class="btn btn-sm btn-link p-0 kpi-config-btn" data-kpi-key="invested_amount" data-kpi-mode="higher" aria-label="Configure Invested Amount">⚙️</button>
           </div>

--- a/core/tests/test_dashboard_template.py
+++ b/core/tests/test_dashboard_template.py
@@ -31,6 +31,21 @@ class TestDashboardTemplate(TestCase):
         self.assertIn("Verification:", html)
         self.assertNotIn("{% include", html)
 
+    @patch(
+        "core.views.DashboardView.get_context_data",
+        return_value={
+            "periods": [],
+            "kpis": {"verified_expenses_pct": 0, "verification_level": "Moderate"},
+        },
+    )
+    def test_average_investment_card_renders(self, mocked_ctx):
+        url = reverse("dashboard")
+        resp = self.client.get(url, secure=True)
+        self.assertEqual(resp.status_code, 200)
+        html = resp.content.decode()
+        self.assertIn("Average Investement", html)
+        self.assertIn('id="valor-investido"', html)
+
     def test_dashboard_template_snapshot(self):
         factory = RequestFactory()
         request = factory.get("/")

--- a/core/views.py
+++ b/core/views.py
@@ -4354,6 +4354,7 @@ def dashboard_kpis_json(request):
         # Calculate averages
         receita_media = total_income / max(num_months, 1)
         despesa_media = total_expenses / max(num_months, 1)
+        investimento_medio = total_investments / max(num_months, 1)
 
         # Calculate savings rate
         savings_rate = (
@@ -4437,7 +4438,7 @@ def dashboard_kpis_json(request):
                 "patrimonio_total": f"{patrimonio_total:,.0f} €",
                 "receita_media": f"{receita_media:,.0f} €",
                 "despesa_estimada_media": f"{despesa_media:,.0f} €",
-                "valor_investido_total": f"{total_investments:,.0f} €",
+                "valor_investido_medio": f"{investimento_medio:,.0f} €",
                 "despesas_justificadas_pct": non_estimated_expense_pct,
                 "despesas_justificadas_pct_str": f"{non_estimated_expense_pct_dec}%",
                 "taxa_poupanca": f"{savings_rate:.1f}%",
@@ -4485,7 +4486,7 @@ def dashboard_kpis_json(request):
                 "patrimonio_total": "0 €",
                 "receita_media": "0 €",
                 "despesa_estimada_media": "0 €",
-                "valor_investido_total": "0 €",
+                "valor_investido_medio": "0 €",
                 "despesas_justificadas_pct": 0.0,
                 "despesas_justificadas_pct_str": "0%",
                 "taxa_poupanca": "0.0%",


### PR DESCRIPTION
## Summary
- Display monthly average investment in dashboard KPI card and rename card to "Average Investement".
- Serve `valor_investido_medio` from `dashboard_kpis_json` endpoint for frontend consumption.
- Update frontend scripts and tests to handle averaged investment metric and tooltip.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a20911b470832cb2b3acf3f105f0c5