### PR TITLE
Relax CSP for runtime styles

### DIFF
--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -279,7 +279,7 @@ CONTENT_SECURITY_POLICY = {
         "style-src": (
             "'self'",
             NONCE,
-            "'unsafe-inline'",
+            "'unsafe-inline'",  # runtime styles from Bootstrap/DataTables
             "https://cdn.jsdelivr.net",
             "https://cdn.datatables.net",
             "https://cdnjs.cloudflare.com",


### PR DESCRIPTION
## Summary
- allow runtime styles by keeping `style-src 'unsafe-inline'` for Bootstrap/DataTables
- document the reason for the CSP exception

## Testing
- `pytest core/tests/test_template_lint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a217a0f364832c84e3d08305d09ee3