### PR TITLE
Handle negative amounts in investment KPI calculation

### DIFF
--- a/core/tests/test_dashboard_investment_kpi.py
+++ b/core/tests/test_dashboard_investment_kpi.py
@@ -1,0 +1,45 @@
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from core.models import Transaction
+
+
+class TestDashboardInvestmentKPI(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            "tester",
+            "tester@example.com",
+            "pass",
+        )
+        self.client.force_login(self.user)
+
+    def test_average_investment_includes_withdrawals(self):
+        Transaction.objects.create(
+            user=self.user,
+            date=date(2024, 1, 10),
+            amount=Decimal("100"),
+            type="IV",
+        )
+        Transaction.objects.create(
+            user=self.user,
+            date=date(2024, 1, 15),
+            amount=Decimal("-150"),
+            type="IV",
+        )
+
+        url = reverse("dashboard_kpis_json")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        avg = float(
+            data["valor_investido_medio"]
+            .replace("€", "")
+            .replace(",", "")
+            .strip()  # noqa: E501
+        )
+        self.assertEqual(avg, -50.0)

--- a/core/views.py
+++ b/core/views.py
@@ -4306,7 +4306,7 @@ def dashboard_kpis_json(request):
 
         total_income = float(stats["total_income"] or 0)
         total_expenses = float(abs(stats["total_expenses"] or 0))  # Make positive
-        total_investments = float(abs(stats["total_investments"] or 0))  # Make positive
+        total_investments = float(stats["total_investments"] or 0)
         total_transactions = stats["total_count"]
         categorized_transactions = stats["categorized_count"]
 


### PR DESCRIPTION
## Summary
- compute investment KPI without forcing positive values so withdrawals are reflected
- add regression test ensuring negative investment averages are returned

## Testing
- `pre-commit run --files core/tests/test_dashboard_investment_kpi.py`
- `pytest core/tests/test_dashboard_investment_kpi.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a21b7d2458832cb795916bcdabb5ff