### PR TITLE
Show account name conflicts to the user

### DIFF
--- a/core/templates/core/account_form.html
+++ b/core/templates/core/account_form.html
@@ -14,9 +14,11 @@
 
   <form method="post" id="account-form" novalidate>
     {% csrf_token %}
-    <div class="d-none">
-      {{ form.non_field_errors }}
-    </div>
+    {% if form.non_field_errors %}
+      <div class="alert alert-danger" role="alert">
+        {{ form.non_field_errors }}
+      </div>
+    {% endif %}
 
     {# Campos do formulário #}
     <div class="mb-3">
@@ -55,4 +57,4 @@
     </div>
   </form>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/core/tests/test_account_duplicate_alert.py
+++ b/core/tests/test_account_duplicate_alert.py
@@ -1,0 +1,29 @@
+import pytest
+from django.urls import reverse
+
+from core.models import Account, AccountType, get_default_currency
+
+
+@pytest.mark.django_db
+def test_duplicate_account_creation_shows_error(client, django_user_model):
+    user = django_user_model.objects.create_user(
+        username="u", password="p"
+    )  # nosec B106
+    client.force_login(user)
+
+    currency = get_default_currency()
+    acc_type = AccountType.objects.get_or_create(name="Savings")[0]
+    Account.objects.create(
+        user=user, name="Main", account_type=acc_type, currency=currency
+    )
+
+    data = {
+        "name": "main",  # duplicate differing only by case
+        "account_type": acc_type.id,
+        "currency": currency.id,
+    }
+
+    response = client.post(reverse("account_create"), data)
+    assert response.status_code == 200  # nosec B101
+    message = b"An account with this name already exists"
+    assert message in response.content  # nosec B101


### PR DESCRIPTION
## Summary
- show account form non-field errors as a visible alert
- add regression test for duplicate account names

## Testing
- `pre-commit run --files core/templates/core/account_form.html core/tests/test_account_duplicate_alert.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a21c97e678832c9e7364c385edd277