### PR TITLE
feat: compute transaction filters in SQL

### DIFF
--- a/core/migrations/0019_tx_filters_rpc.py
+++ b/core/migrations/0019_tx_filters_rpc.py
@@ -1,0 +1,62 @@
+from django.db import migrations
+
+TX_FILTERS_FUNCTION = """
+CREATE OR REPLACE FUNCTION tx_filters(_user uuid, _period text DEFAULT NULL)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT jsonb_build_object(
+        'types', (
+            SELECT jsonb_agg(DISTINCT t.type)
+            FROM core_transaction t
+            WHERE t.user_id = _user
+              AND (_period IS NULL OR t.period = _period)
+        ),
+        'categories', (
+            SELECT jsonb_agg(DISTINCT c.name)
+            FROM core_transaction t
+            JOIN core_category c ON c.id = t.category_id
+            WHERE t.user_id = _user
+              AND (_period IS NULL OR t.period = _period)
+        ),
+        'accounts', (
+            SELECT jsonb_agg(DISTINCT a.name)
+            FROM core_transaction t
+            JOIN core_account a ON a.id = t.account_id
+            WHERE t.user_id = _user
+              AND (_period IS NULL OR t.period = _period)
+        ),
+        'periods', (
+            SELECT jsonb_agg(DISTINCT t.period)
+            FROM core_transaction t
+            WHERE t.user_id = _user
+        )
+    );
+$$;
+"""
+
+DROP_TX_FILTERS_FUNCTION = "DROP FUNCTION IF EXISTS tx_filters(uuid, text);"
+
+
+def create_tx_filters(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute(TX_FILTERS_FUNCTION)
+
+
+def drop_tx_filters(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute(DROP_TX_FILTERS_FUNCTION)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0018_remove_account_unique_account_user_name_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_tx_filters, drop_tx_filters),
+    ]

--- a/core/tests/test_etag_headers.py
+++ b/core/tests/test_etag_headers.py
@@ -1,10 +1,10 @@
 import json
+import os
 from datetime import date
 from decimal import Decimal
-from unittest import skipIf
+from unittest import mock
 
 from django.contrib.auth import get_user_model
-from django.db import connection
 from django.test import TestCase
 from django.urls import reverse
 
@@ -62,11 +62,48 @@ class ETagHeadersTest(TestCase):
         )
         self.assertEqual(response_304_lm.status_code, 304)
 
-    @skipIf(
-        connection.vendor == "sqlite",
-        "transactions_json_v2 uses PostgreSQL-specific SQL",
+    @mock.patch.dict(
+        os.environ,
+        {
+            "SUPABASE_REST_URL": "http://test",
+            "SUPABASE_API_KEY": "key",
+            "SUPABASE_JWT_SECRET": "secret",
+        },
     )
-    def test_transactions_json_v2_etag(self):
+    @mock.patch("core.views.requests.post")
+    @mock.patch("core.views.requests.get")
+    def test_transactions_json_v2_etag(self, mock_get, mock_post):
+        tx_resp = mock.Mock()
+        tx_resp.json.return_value = [
+            {
+                "id": 1,
+                "date": "2024-01-01",
+                "type": "IN",
+                "amount": 10,
+                "category": {"name": "Cat"},
+                "account": {"name": "Acc"},
+                "period": "2024-01",
+                "description": "d",
+                "tags": "",
+                "is_system": False,
+                "editable": True,
+                "is_estimated": False,
+            }
+        ]
+        tx_resp.headers = {"Content-Range": "0-0/1"}
+        tx_resp.raise_for_status = lambda: None
+        mock_get.return_value = tx_resp
+
+        filt_resp = mock.Mock()
+        filt_resp.json.return_value = {
+            "types": ["Income"],
+            "categories": ["Cat"],
+            "accounts": ["Acc"],
+            "periods": ["2024-01"],
+        }
+        filt_resp.raise_for_status = lambda: None
+        mock_post.return_value = filt_resp
+
         url = reverse("transactions_json_v2")
         params = {"date_start": "2024-01-01", "date_end": "2024-12-31"}
         response = self.client.get(url, params)


### PR DESCRIPTION
## Summary
- fetch transaction data and filter options from PostgREST instead of Django
- add `tx_filters` PostgreSQL RPC for distinct types, categories, accounts and periods
- honor `If-Modified-Since` in `transactions_json_v2` and cover the endpoint with tests

## Testing
- `python -m py_compile core/migrations/0019_tx_filters_rpc.py`
- `python -m py_compile core/views.py`
- `python -m py_compile core/tests/test_etag_headers.py`
- `pytest core/tests/test_etag_headers.py::ETagHeadersTest::test_transactions_json_v2_etag -q`
- `pytest core/tests/test_etag_headers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a21fbb0a94832c87c742fc7fa463e8