### PR TITLE
Show lazy instructions in modal

### DIFF
--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -796,7 +796,12 @@
             <i class="bi bi-rocket-takeoff me-2"></i>
             Start Your Free Beta
           </a>
-          <a href="#features" class="btn btn-outline-light btn-lg">
+          <a
+            href="#"
+            class="btn btn-outline-light btn-lg"
+            data-bs-toggle="modal"
+            data-bs-target="#lazyInstructionsModal"
+          >
             <i class="bi bi-info-circle me-2"></i>
             Learn More
           </a>
@@ -806,7 +811,33 @@
   </div>
 </section>
 
-{% include "core/partials/lazy_instructions.html" %}
+<!-- Lazy instructions modal -->
+<div
+  class="modal fade"
+  id="lazyInstructionsModal"
+  tabindex="-1"
+  aria-labelledby="lazyInstructionsModalLabel"
+  aria-hidden="true"
+>
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="lazyInstructionsModalLabel">
+          Made for the Lazy: Manage Your Money with 3 Simple Steps
+        </h1>
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="Close"
+        ></button>
+      </div>
+      <div class="modal-body">
+        {% include "core/partials/lazy_instructions.html" %}
+      </div>
+    </div>
+  </div>
+</div>
 
 {% endblock content %}
 
@@ -815,13 +846,19 @@
 document.addEventListener('DOMContentLoaded', function() {
   // Smooth scrolling for anchor links
   document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+    if (anchor.dataset.bsToggle === 'modal') {
+      return;
+    }
     anchor.addEventListener('click', function (e) {
       e.preventDefault();
-      const target = document.querySelector(this.getAttribute('href'));
-      if (target) {
-        target.scrollIntoView({
-          behavior: 'smooth'
-        });
+      const selector = this.getAttribute('href');
+      if (selector.length > 1) {
+        const target = document.querySelector(selector);
+        if (target) {
+          target.scrollIntoView({
+            behavior: 'smooth'
+          });
+        }
       }
     });
   });

--- a/core/templates/core/partials/lazy_instructions.html
+++ b/core/templates/core/partials/lazy_instructions.html
@@ -1,5 +1,3 @@
-<h1 class="mt-3 mb-3">Made for the Lazy: Manage Your Money with 3 Simple Steps</h1>
-
 <div class="card mb-4">
   <div class="card-body">
     <p class="mb-3">


### PR DESCRIPTION
## Summary
- display lazy-mode instructions inside a Bootstrap modal
- convert Learn More button to open modal and skip smooth scrolling

## Testing
- `pre-commit run --files core/templates/core/home.html core/templates/core/partials/lazy_instructions.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a24d21620c832cba9e74bab12a9927