### PR TITLE
Replace support email with noreply address

### DIFF
--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -664,7 +664,7 @@
             Questions or support needed? We're here to help with your financial tracking journey.
           </p>
           <p class="text-muted small">
-            <strong>Email:</strong> support@ourfinancetracker.com<br>
+            <strong>Email:</strong> <a href="mailto:noreply@ourfinancetracker.com">noreply@ourfinancetracker.com</a><br>
             Support available during beta phase
           </p>
         </div>

--- a/core/templates/core/partials/contact.html
+++ b/core/templates/core/partials/contact.html
@@ -1,6 +1,6 @@
 <div class="card mb-4">
   <div class="card-body">
     <h2 class="h5 mb-2">Need help?</h2>
-    <p class="mb-0">Reach out at <a href="mailto:support@ourfinancetracker.com">support@ourfinancetracker.com</a>.</p>
+    <p class="mb-0">Reach out at <a href="mailto:noreply@ourfinancetracker.com">noreply@ourfinancetracker.com</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- replace references to support email with noreply@ourfinancetracker.com in templates
- make home page email address a clickable mailto link

## Testing
- `DATABASE_URL=sqlite:////tmp/testdb.sqlite3 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2f7722d08832cb277f6720a7b6491