### PR TITLE
chore: refresh dependencies for Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,73 +1,73 @@
-
 # Core framework
-Django==5.1.11
+Django>=5.2.5
 
 # Django extensions and utilities
-django-extensions==4.1
-django-widget-tweaks==1.5.0
-django-cors-headers==4.7.0
+django-extensions>=4.1
+django-widget-tweaks>=1.5.0
+django-cors-headers>=4.7.0
 
 # Database
-psycopg2-binary==2.9.10
-dj-database-url==3.0.1
+psycopg2-binary>=2.9.10
+dj-database-url>=3.0.1
 
 # Cache (Redis for production)
-redis==6.4.0
-django-redis==6.0.0
+redis>=6.4.0
+django-redis>=6.0.0
 
 # Security and authentication
-django-axes==6.5.2
-django-ratelimit==4.1.0
-django-csp==4.0
-argon2-cffi==25.1.0
-PyJWT==2.10.1
+django-axes>=8.0.0
+django-ratelimit>=4.1.0
+django-csp>=4.0
+argon2-cffi>=25.1.0
+PyJWT>=2.10.1
 
 # Environment configuration
-python-dotenv==1.1.1
+python-dotenv>=1.1.1
 
 # Data analysis and manipulation
-pandas==2.3.1
-numpy==2.3.2
+pandas>=2.3.1
+numpy>=2.3.2
 
 # File export
-openpyxl==3.1.5
-xlsxwriter==3.2.5
+openpyxl>=3.1.5
+xlsxwriter>=3.2.5
 
 # Date processing
-python-dateutil==2.9.0.post0
+python-dateutil>=2.9.0.post0
 
 # Task queue
-celery==5.5.3
-django-celery-beat==2.8.1
+celery>=5.5.3
+django-celery-beat>=2.8.1
 
 # Development and debug
-django-debug-toolbar==6.0.0
+django-debug-toolbar>=6.0.0
 
 # Production server
-gunicorn==23.0.0
-whitenoise==6.9.0
+gunicorn>=23.0.0
+whitenoise>=6.9.0
+htmlmin2>=0.1.13
 
 # HTTP requests and utilities
-requests==2.32.4
-pytz==2025.2
+requests>=2.32.4
+pytz>=2025.2
 
 # Structured logging
-django-structlog==9.1.1
+django-structlog>=9.1.1
 
 # Error monitoring
-sentry-sdk==2.19.2
+sentry-sdk>=2.35.0
 
 # Backup utilities
-django-dbbackup==4.3.0
+django-dbbackup>=4.3.0
 
 # Code quality (development)
-flake8==7.3.0
-black==25.1.0
-isort==6.0.1
+flake8>=7.3.0
+black>=25.1.0
+isort>=6.0.1
 
 # Testing
-pytest==8.4.1
-pytest-django==4.11.1
-pytest-cov==6.2.1
-django-anymail==13.0.1
-resend==2.13.0
+pytest>=8.4.1
+pytest-django>=4.11.1
+pytest-cov>=6.2.1
+django-anymail>=13.0.1
+resend>=2.13.0


### PR DESCRIPTION
## Summary
- replace deprecated htmlmin with htmlmin2
- relax dependency pins and bump versions for Python 3.13 compatibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a345b746d8832c81390ced54d4f58a