### PR TITLE
Add type and period grouping to mobile transactions view

### DIFF
--- a/core/static/js/transaction_list_v2.js
+++ b/core/static/js/transaction_list_v2.js
@@ -1027,6 +1027,12 @@ class TransactionManager {
     if (this.groupBy === 'account') {
       return tx.account || 'No account';
     }
+    if (this.groupBy === 'type') {
+      return tx.type || 'No type';
+    }
+    if (this.groupBy === 'period') {
+      return tx.period || 'No period';
+    }
     return '';
   }
 

--- a/core/templates/core/transaction_list_v2.html
+++ b/core/templates/core/transaction_list_v2.html
@@ -282,6 +282,8 @@
           <option value="category">Category</option>
           <option value="month">Month</option>
           <option value="account">Account</option>
+          <option value="type">Type</option>
+          <option value="period">Period</option>
         </select>
       </div>
 


### PR DESCRIPTION
## Summary
- add Type and Period options to group-by selector in transactions V2
- implement group key logic for new grouping modes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a389ed8e10832c8e2b264d9e9353d3