### PR TITLE
harden HTTPS and cookie settings

### DIFF
--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -4,12 +4,14 @@ CSP (django-csp), WhiteNoise, optional Redis, Debug Toolbar, and django-axes.
 """
 
 from __future__ import annotations
+
 import os
 import warnings
 from pathlib import Path
-from dotenv import load_dotenv
-from csp.constants import NONCE
+
 import sentry_sdk
+from csp.constants import NONCE
+from dotenv import load_dotenv
 from sentry_sdk.integrations.django import DjangoIntegration
 
 try:
@@ -24,6 +26,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(BASE_DIR / ".env")
 ENV = os.getenv
 
+
 def env_bool(key: str, default: str = "false") -> bool:
     return ENV(key, default).lower() in {"1", "true", "yes", "on"}
 
@@ -35,6 +38,7 @@ def strtobool(val: str) -> bool:
     if val in {"n", "no", "f", "false", "off", "0"}:
         return False
     raise ValueError(f"invalid truth value {val}")
+
 
 # ────────────────────────────────────────────────────
 # Core flags & secret
@@ -82,42 +86,79 @@ ALLOWED_HOSTS = [
 CSRF_TRUSTED_ORIGINS = [
     "https://ourfinancetracker.com",
     "https://www.ourfinancetracker.com",
-    "http://localhost:8000", "http://localhost:8001",
-    "http://127.0.0.1:8000", "http://127.0.0.1:8001",
-    "http://localhost:3000", "http://127.0.0.1:3000",
-    "http://localhost:5000", "http://127.0.0.1:5000",
-    "https://98b987c2-efd3-4289-a8a5-45cacedf5eaa-00-2urxof032vq30.riker.replit.dev:5000",
-    "http://98b987c2-efd3-4289-a8a5-45cacedf5eaa-00-2urxof032vq30.riker.replit.dev:5000",
-    "https://98b987c2-efd3-4289-a8a5-45cacedf5eaa-00-2urxof032vq30.riker.replit.dev",
-    "http://98b987c2-efd3-4289-a8a5-45cacedf5eaa-00-2urxof032vq30.riker.replit.dev",
+    "http://localhost:8000",
+    "http://localhost:8001",
+    "http://127.0.0.1:8000",
+    "http://127.0.0.1:8001",
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:5000",
+    "http://127.0.0.1:5000",
+    (
+        "https://98b987c2-efd3-4289-a8a5-45cacedf5eaa-00-2urxof032vq30"
+        ".riker.replit.dev:5000"
+    ),
+    (
+        "http://98b987c2-efd3-4289-a8a5-45cacedf5eaa-00-2urxof032vq30"
+        ".riker.replit.dev:5000"
+    ),
+    (
+        "https://98b987c2-efd3-4289-a8a5-45cacedf5eaa-00-2urxof032vq30"
+        ".riker.replit.dev"
+    ),
+    (
+        "http://98b987c2-efd3-4289-a8a5-45cacedf5eaa-00-2urxof032vq30"
+        ".riker.replit.dev"
+    ),
 ]
 
-def _extend_from_env_list(env_key: str, target_list: list[str], require_scheme: bool = False) -> None:
+
+def _extend_from_env_list(
+    env_key: str, target_list: list[str], require_scheme: bool = False
+) -> None:
     raw = ENV(env_key, "") or ""
     if not raw:
         return
     for item in [x.strip() for x in raw.split(",") if x.strip()]:
-        if require_scheme and not (item.startswith("http://") or item.startswith("https://")):
+        if require_scheme and not (
+            item.startswith("http://") or item.startswith("https://")
+        ):
             continue
         target_list.append(item)
+
 
 if ENV("REPLIT_DEV_DOMAIN"):
     dom = ENV("REPLIT_DEV_DOMAIN")
     ALLOWED_HOSTS.append(dom)
-    CSRF_TRUSTED_ORIGINS += [f"https://{dom}", f"http://{dom}"]
+    CSRF_TRUSTED_ORIGINS += [
+        f"https://{dom}",
+        f"http://{dom}",
+    ]
 
-# Replit domain configuration handled above in ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS
+# Replit domain configuration handled above
 
-_extend_from_env_list("EXTRA_ALLOWED_HOSTS", ALLOWED_HOSTS, require_scheme=False)
-_extend_from_env_list("EXTRA_CSRF_TRUSTED_ORIGINS", CSRF_TRUSTED_ORIGINS, require_scheme=True)
+_extend_from_env_list(
+    "EXTRA_ALLOWED_HOSTS",
+    ALLOWED_HOSTS,
+    require_scheme=False,
+)
+_extend_from_env_list(
+    "EXTRA_CSRF_TRUSTED_ORIGINS",
+    CSRF_TRUSTED_ORIGINS,
+    require_scheme=True,
+)
 
 # ────────────────────────────────────────────────────
 # Apps & Middleware
 # ────────────────────────────────────────────────────
 INSTALLED_APPS = [
     # Django
-    "django.contrib.admin", "django.contrib.auth", "django.contrib.contenttypes",
-    "django.contrib.sessions", "django.contrib.messages", "django.contrib.staticfiles",
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
     "django.contrib.sites",
     # Third-party
     "whitenoise.runserver_nostatic",
@@ -150,7 +191,8 @@ MIDDLEWARE = [
 ]
 if DEBUG:
     MIDDLEWARE.append("core.middleware.performance.PerformanceMiddleware")
-MIDDLEWARE.append("axes.middleware.AxesMiddleware")  # axes middleware must come last
+MIDDLEWARE.append("axes.middleware.AxesMiddleware")
+# axes middleware must come last
 
 if DEBUG and SHOW_DEBUG_TOOLBAR:
     MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
@@ -170,7 +212,10 @@ WSGI_APPLICATION = "ourfinancetracker_site.wsgi.application"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [BASE_DIR / "accounts" / "templates", BASE_DIR / "core" / "templates"],
+        "DIRS": [
+            BASE_DIR / "accounts" / "templates",
+            BASE_DIR / "core" / "templates",
+        ],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -185,13 +230,13 @@ TEMPLATES = [
 ]
 
 # ────────────────────────────────────────────────────
-# Database (Supabase preferred via SUPABASE_DB_URL/DATABASE_URL; fallback SQLite)
+# Database (Supabase via SUPABASE_DB_URL/DATABASE_URL; fallback SQLite)
 # ────────────────────────────────────────────────────
 SUPA_URL = ENV("SUPABASE_DB_URL") or ENV("DATABASE_URL")
 if not SUPA_URL and ENV("DB_HOST"):
     SUPA_URL = (
         f"postgresql://{ENV('DB_USER')}:{ENV('DB_PASSWORD')}"
-        f"@{ENV('DB_HOST')}:{ENV('DB_PORT','5432')}/{ENV('DB_NAME')}"
+        f"@{ENV('DB_HOST')}:{ENV('DB_PORT', '5432')}/{ENV('DB_NAME')}"
     )
 
 if SUPA_URL and dj_database_url:
@@ -204,7 +249,10 @@ if SUPA_URL and dj_database_url:
     }
 else:
     DATABASES = {
-        "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
     }
 
 # ────────────────────────────────────────────────────
@@ -221,7 +269,12 @@ if ENV("REDIS_URL"):
         }
     }
 else:
-    CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "ourft-cache"}}
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "ourft-cache",
+        }
+    }
 
 # ────────────────────────────────────────────────────
 # I18N
@@ -238,7 +291,8 @@ STATIC_URL = "/static/"
 STATICFILES_DIRS = [BASE_DIR / "core" / "static"]
 STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_STORAGE = (
-    "django.contrib.staticfiles.storage.StaticFilesStorage" if DEBUG
+    "django.contrib.staticfiles.storage.StaticFilesStorage"
+    if DEBUG
     else "whitenoise.storage.CompressedManifestStaticFilesStorage"
 )
 WHITENOISE_USE_FINDERS = True
@@ -263,10 +317,22 @@ PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.BCryptSHA256PasswordHasher",
 ]
 AUTH_PASSWORD_VALIDATORS = [
-    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
-    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator", "OPTIONS": {"min_length": 12}},
-    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
-    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
+    {
+        "NAME": (
+            "django.contrib.auth.password_validation."
+            "UserAttributeSimilarityValidator"
+        )
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",  # noqa: E501
+        "OPTIONS": {"min_length": 12},
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",  # noqa: E501
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",  # noqa: E501
+    },
 ]
 
 # ────────────────────────────────────────────────────
@@ -309,8 +375,11 @@ CONTENT_SECURITY_POLICY = {
 if not DEBUG:
     CONTENT_SECURITY_POLICY["DIRECTIVES"]["upgrade-insecure-requests"] = []
 
-SESSION_COOKIE_SAMESITE = ENV("SESSION_COOKIE_SAMESITE", "Strict")
-CSRF_COOKIE_SAMESITE = ENV("CSRF_COOKIE_SAMESITE", "Strict")
+# Harden session and CSRF cookies by default
+SESSION_COOKIE_SAMESITE = "Strict"
+CSRF_COOKIE_SAMESITE = "Strict"
+SESSION_COOKIE_HTTPONLY = True
+CSRF_COOKIE_HTTPONLY = True  # set to False if JS needs to read it
 
 if DEBUG:
     # Dev: no forced HTTPS
@@ -320,15 +389,17 @@ if DEBUG:
     # Cookies & CSRF over HTTP
     SESSION_COOKIE_SECURE = False
     CSRF_COOKIE_SECURE = False
-    CSRF_COOKIE_HTTPONLY = False
     CSRF_USE_SESSIONS = False
     CSRF_FAILURE_VIEW = "django.views.csrf.csrf_failure"
 
     # Trusted origins (HTTP + ports)
     CSRF_TRUSTED_ORIGINS += [
-        "http://127.0.0.1:8000", "http://127.0.0.1:8001",
-        "http://localhost:8000", "http://localhost:8001",
-        "http://localhost:3000", "http://127.0.0.1:3000",
+        "http://127.0.0.1:8000",
+        "http://127.0.0.1:8001",
+        "http://localhost:8000",
+        "http://localhost:8001",
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
     ]
 
 else:
@@ -347,16 +418,23 @@ else:
     # Cookies & CSRF
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
-    SESSION_COOKIE_HTTPONLY = True
-    CSRF_COOKIE_HTTPONLY = True  # set to False if JS needs to read it
 
 
 # ────────────────────────────────────────────────────
 # Email
 # ────────────────────────────────────────────────────
-EMAIL_BACKEND = ENV("EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend")
-DEFAULT_FROM_EMAIL = ENV("DEFAULT_FROM_EMAIL", "noreply@ourfinancetracker.com")
-EMAIL_LINK_DOMAIN = ENV("EMAIL_LINK_DOMAIN", "www.ourfinancetracker.com")
+EMAIL_BACKEND = ENV(
+    "EMAIL_BACKEND",
+    "django.core.mail.backends.smtp.EmailBackend",
+)
+DEFAULT_FROM_EMAIL = ENV(
+    "DEFAULT_FROM_EMAIL",
+    "noreply@ourfinancetracker.com",
+)
+EMAIL_LINK_DOMAIN = ENV(
+    "EMAIL_LINK_DOMAIN",
+    "www.ourfinancetracker.com",
+)
 EMAIL_HOST = ENV("EMAIL_HOST", "")
 EMAIL_PORT = int(ENV("EMAIL_PORT", "587"))
 EMAIL_USE_TLS = env_bool("EMAIL_USE_TLS", "true")
@@ -383,10 +461,16 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "handlers": {
-        "console": {"class": "logging.StreamHandler", "level": "DEBUG"},
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+        },
         "null": {"class": "logging.NullHandler"},
     },
-    "root": {"handlers": ["console"] if DEBUG else ["null"], "level": "DEBUG" if DEBUG else "INFO"},
+    "root": {
+        "handlers": ["console"] if DEBUG else ["null"],
+        "level": "DEBUG" if DEBUG else "INFO",
+    },
     "loggers": {
         "django.server": {
             "handlers": ["console"] if DEBUG else ["null"],
@@ -411,11 +495,17 @@ SUPABASE_JWT_SECRET = ENV("SUPABASE_JWT_SECRET")
 # Celery
 if DEBUG:
     CELERY_BROKER_URL = ENV("CELERY_BROKER_URL", default="memory://")
-    CELERY_RESULT_BACKEND = ENV("CELERY_RESULT_BACKEND", default="cache+memory://")
+    CELERY_RESULT_BACKEND = ENV(
+        "CELERY_RESULT_BACKEND",
+        default="cache+memory://",
+    )
 else:
     _redis_default = ENV("REDIS_URL", "redis://localhost:6379/0")
     CELERY_BROKER_URL = ENV("CELERY_BROKER_URL", default=_redis_default)
-    CELERY_RESULT_BACKEND = ENV("CELERY_RESULT_BACKEND", default=_redis_default)
+    CELERY_RESULT_BACKEND = ENV(
+        "CELERY_RESULT_BACKEND",
+        default=_redis_default,
+    )
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
@@ -428,7 +518,10 @@ if DEBUG:
     SESSION_COOKIE_SECURE = False
 
     # Do not emit the CSP upgrade directive in dev
-    CONTENT_SECURITY_POLICY["DIRECTIVES"].pop("upgrade-insecure-requests", None)
+    CONTENT_SECURITY_POLICY["DIRECTIVES"].pop(
+        "upgrade-insecure-requests",
+        None,
+    )
 
     # No HSTS while on HTTP
     SECURE_HSTS_SECONDS = 0


### PR DESCRIPTION
## Summary
- default session and CSRF cookies to Strict, HTTPOnly
- ensure production enforces HTTPS with HSTS and secure cookies
- format settings to satisfy flake8 line-length checks

## Testing
- `pre-commit run --files ourfinancetracker_site/settings.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a38b14fa08832ca029552ac03e0882