### PR TITLE
Add login fuzzing and SQL injection tests

### DIFF
--- a/accounts/tests/test_fuzz_and_injection.py
+++ b/accounts/tests/test_fuzz_and_injection.py
@@ -1,0 +1,32 @@
+import string
+
+import pytest
+from django.urls import reverse
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+
+@pytest.mark.django_db
+@given(
+    username=st.text(alphabet=string.ascii_letters + string.digits, max_size=20),
+    password=st.text(alphabet=string.ascii_letters + string.digits, max_size=50),
+)
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test_login_fuzz(client, settings, username, password):
+    settings.SECURE_SSL_REDIRECT = False
+    response = client.post(
+        reverse("accounts:login"), {"username": username, "password": password}
+    )
+    assert response.status_code < 500
+
+
+@pytest.mark.django_db
+def test_login_sql_injection_attempt(client, settings):
+    settings.SECURE_SSL_REDIRECT = False
+    payload = "' OR '1'='1"
+    response = client.post(reverse("accounts:login"), {"username": payload, "password": payload})
+    assert response.status_code == 200
+    assert client.session.get("_auth_user_id") is None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,3 +29,5 @@ requests==2.32.4  # <- para proxy seguro com Supabase REST API
 # ───── Webserver local (produção/dev) ─────
 gunicorn==23.0.0
 
+# ───── Fuzz testing ─────
+hypothesis==6.138.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,3 +71,4 @@ pytest-django==4.11.1
 pytest-cov==6.2.1
 django-anymail==13.0.1
 resend==2.13.0
+hypothesis==6.138.2


### PR DESCRIPTION
## Summary
- add Hypothesis to dev requirements for fuzz testing
- add login fuzzing and SQL injection regression tests

## Testing
- `pip-audit -r requirements.txt --progress-spinner off`
- `pip-audit -r requirements-dev.txt --progress-spinner off`
- `bandit accounts/tests/test_fuzz_and_injection.py -ll`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a38b4a194c832ca6002dcd3006cd37