### PR TITLE
Handle comma decimal amounts in transaction import

### DIFF
--- a/core/tests/test_import_export.py
+++ b/core/tests/test_import_export.py
@@ -51,6 +51,23 @@ def test_bulk_importer_duplicate_rows():
 
 
 @pytest.mark.django_db
+def test_bulk_importer_amount_with_comma_decimal():
+    user = User.objects.create_user('u_comma')
+    df = pd.DataFrame({
+        'Date': ['2024-01-01'],
+        'Type': ['IN'],
+        'Amount': ['10,35'],
+        'Category': ['Salary'],
+        'Account': ['Bank'],
+    })
+    importer = import_helpers.BulkTransactionImporter(user)
+    result = importer.import_dataframe(df)
+    assert result['imported'] == 1
+    transaction = Transaction.objects.get(user=user)
+    assert transaction.amount == Decimal('10.35')
+
+
+@pytest.mark.django_db
 def test_bulk_importer_large_file_chunked():
     user = User.objects.create_user('u4')
     rows = 2100

--- a/core/utils/import_helpers.py
+++ b/core/utils/import_helpers.py
@@ -115,7 +115,9 @@ class BulkTransactionImporter:
         try:
             logger.info(f"🔄 [BulkTransactionImporter] Converting data types...")
             df_clean['Date'] = pd.to_datetime(df_clean['Date']).dt.date
-            df_clean['Amount'] = df_clean['Amount'].astype(float)
+            df_clean['Amount'] = (
+                df_clean['Amount'].astype(str).str.replace(',', '.').astype(float)
+            )
 
             logger.debug(f"📅 [BulkTransactionImporter] Date range: {df_clean['Date'].min()} to {df_clean['Date'].max()}")
             logger.debug(f"💰 [BulkTransactionImporter] Amount range: {df_clean['Amount'].min()} to {df_clean['Amount'].max()}")


### PR DESCRIPTION
## Summary
- allow `_clean_dataframe` to convert amounts with comma decimal separators
- add regression test for comma-separated decimals

## Testing
- `python -m pytest core/tests/test_import_export.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b866a2cb98832c8f04b99628434fcc