### PR TITLE
Fix month selector navigation in account balances view

### DIFF
--- a/core/static/js/account_balance.js
+++ b/core/static/js/account_balance.js
@@ -589,6 +589,16 @@ document.addEventListener("DOMContentLoaded", () => {
       availableAccounts = [];
     }
   }
+
+  // Month selector navigation
+  const monthSelector = document.getElementById("selector");
+  if (monthSelector) {
+    monthSelector.addEventListener("change", () => {
+      const [year, month] = monthSelector.value.split("-");
+      window.location.search = `?year=${year}&month=${parseInt(month, 10)}`;
+    });
+    console.log("✅ [account_balance.js] Month selector handler initialized");
+  }
   
   // Add row button
   const addBtn = document.getElementById("add-row-btn");

--- a/core/templates/core/account_balance.html
+++ b/core/templates/core/account_balance.html
@@ -17,7 +17,6 @@
               <div class="btn-group" role="group">
                 <a class="btn btn-outline-secondary btn-sm" href="?year={{ year }}&month={{ month|add:'-1' }}">‹ Prev</a>
                 <input type="month" id="selector" value="{{ year }}-{{ month|stringformat:'02d' }}"
-                       onchange="window.location='?month='+this.value.split('-')[1]+'&year='+this.value.split('-')[0];"
                        class="form-control form-control-sm w-auto">
                 <a class="btn btn-outline-secondary btn-sm" href="?year={{ year }}&month={{ month|add:'1' }}">Next ›</a>
               </div>
@@ -215,4 +214,4 @@
 <script src="{% static 'js/account_balance.js' %}" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script src="{% static 'js/drag_reorder.js' %}" defer></script>
-{% endblock %}
+{% endblock content %}


### PR DESCRIPTION
## Summary
- handle month selector change in account_balance.js
- tidy template endblock name

## Testing
- `pre-commit run --files core/static/js/account_balance.js core/templates/core/account_balance.html`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b869b3b7f4832cad2607a42b18bdaf