### PR TITLE
Allow eval-based scripts in CSP

### DIFF
--- a/ourfinancetracker_site/settings.py
+++ b/ourfinancetracker_site/settings.py
@@ -313,6 +313,7 @@ CONTENT_SECURITY_POLICY = {
         "default-src": ("'self'",),
         "script-src": (
             "'self'",
+            "'unsafe-eval'",
             NONCE,
             "https://cdn.jsdelivr.net",
             "https://cdn.datatables.net",


### PR DESCRIPTION
## Summary
- add `'unsafe-eval'` to the CSP `script-src` directive to permit libraries requiring string evaluation

## Testing
- `pytest core/tests/test_csp_headers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8733d3a48832ca7f0cd9627c329cd