### PR TITLE
Fix account row insertion for empty months

### DIFF
--- a/core/static/js/account_balance.js
+++ b/core/static/js/account_balance.js
@@ -119,7 +119,8 @@ function addRow() {
     }
     
     // Find insertion point (before action bar)
-    const actionBar = form.querySelector(".card:last-child");
+    const addRowButton = document.getElementById('add-row-btn');
+    const actionBar = addRowButton ? addRowButton.closest('.card') : null;
     if (!actionBar) {
       console.error("❌ [addRow] Could not find insertion point");
       return;


### PR DESCRIPTION
## Summary
- prevent account balance form from failing when adding first row by detecting action bar via add-row button

## Testing
- `DATABASE_URL=sqlite:////tmp/testdb.sqlite3 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c30a137168832c96b305fb09807bfc