### PR TITLE
Fix account balance month navigation rollover

### DIFF
--- a/core/templates/core/account_balance.html
+++ b/core/templates/core/account_balance.html
@@ -15,10 +15,10 @@
             <div class="d-flex align-items-center gap-2">
               <!-- Month Navigation -->
               <div class="btn-group" role="group">
-                <a class="btn btn-outline-secondary btn-sm" href="?year={{ year }}&month={{ month|add:'-1' }}">‹ Prev</a>
+                <a class="btn btn-outline-secondary btn-sm" href="?year={{ prev_year }}&month={{ prev_month }}">‹ Prev</a>
                 <input type="month" id="selector" value="{{ year }}-{{ month|stringformat:'02d' }}"
                        class="form-control form-control-sm w-auto">
-                <a class="btn btn-outline-secondary btn-sm" href="?year={{ year }}&month={{ month|add:'1' }}">Next ›</a>
+                <a class="btn btn-outline-secondary btn-sm" href="?year={{ next_year }}&month={{ next_month }}">Next ›</a>
               </div>
 
               <!-- Actions -->

--- a/core/tests/test_account_balance_navigation.py
+++ b/core/tests/test_account_balance_navigation.py
@@ -1,0 +1,32 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "year,month,prev_year,prev_month,next_year,next_month",
+    [
+        (2026, 1, 2025, 12, 2026, 2),
+        (2026, 12, 2026, 11, 2027, 1),
+        (2026, 6, 2026, 5, 2026, 7),
+    ],
+)
+def test_account_balance_prev_next_links_rollover_correctly(
+    client,
+    django_user_model,
+    year,
+    month,
+    prev_year,
+    prev_month,
+    next_year,
+    next_month,
+):
+    user = django_user_model.objects.create_user(username="u", password="p")
+    client.force_login(user)
+
+    response = client.get(reverse("account_balance"), {"year": year, "month": month})
+
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert f'href="?year={prev_year}&month={prev_month}"' in html
+    assert f'href="?year={next_year}&month={next_month}"' in html

--- a/core/views.py
+++ b/core/views.py
@@ -3231,6 +3231,16 @@ def account_balance_view(request):
                 grouped_forms[key] = []
             grouped_forms[key].append(form)
 
+    if month == 1:
+        prev_year, prev_month = year - 1, 12
+    else:
+        prev_year, prev_month = year, month - 1
+
+    if month == 12:
+        next_year, next_month = year + 1, 1
+    else:
+        next_year, next_month = year, month + 1
+
     context = {
         "formset": formset,
         "grouped_forms": grouped_forms,
@@ -3238,6 +3248,10 @@ def account_balance_view(request):
         "grand_total": grand_total,
         "year": year,
         "month": month,
+        "prev_year": prev_year,
+        "prev_month": prev_month,
+        "next_year": next_year,
+        "next_month": next_month,
         "selected_month": date(year, month, 1),
         "available_accounts": available_accounts,
     }
@@ -3249,6 +3263,10 @@ def account_balance_view(request):
             "grand_total": grand_total,
             "year": year,
             "month": month,
+            "prev_year": prev_year,
+            "prev_month": prev_month,
+            "next_year": next_year,
+            "next_month": next_month,
             "selected_month": date(year, month, 1),
         }
         cache.set(cache_key, cache_safe_context, timeout=600)  # 10 minutes cache


### PR DESCRIPTION
### Motivation

- Templates used `month|add:'-1'` / `month|add:'1'` which produced invalid month values (`0` or `13`) at year boundaries and broke Prev/Next navigation on `/account-balance`.

### Description

- Moved month arithmetic into the view `account_balance_view` and compute `prev_year/prev_month` and `next_year/next_month` with proper year rollovers.
- Added the new context keys `prev_year`, `prev_month`, `next_year`, and `next_month` to the view's `context` and `cache_safe_context`.
- Updated the template `core/templates/core/account_balance.html` to use `prev_year/prev_month` and `next_year/next_month` for the Prev/Next links instead of `month|add`.
- Added a regression test `core/tests/test_account_balance_navigation.py` that asserts correct Prev/Next links for January, December, and a middle month.

### Testing

- Ran `pytest -q core/tests/test_account_balance_navigation.py` and the new test suite passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6f7ef3850832ca498abc53111b8d0)