### PR TITLE
Fix dashboard period fallback and year-rollover navigation

### DIFF
--- a/core/tests/test_dashboard_period.py
+++ b/core/tests/test_dashboard_period.py
@@ -36,3 +36,21 @@ class TestDashboardPeriodMode(TestCase):
         self.assertIn("Income", html)
         self.assertIn("Expenses", html)
 
+    def test_period_navigation_crosses_year_boundary(self):
+        url = reverse("dashboard")
+        resp = self.client.get(url, {"mode": "period", "period": "2025-12"}, secure=True)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context["prev_period"], "2025-11")
+        self.assertEqual(resp.context["next_period"], "2026-01")
+
+    def test_invalid_period_falls_back_to_default_period(self):
+        url = reverse("dashboard")
+        resp = self.client.get(
+            url,
+            {"mode": "period", "period": "2025-13"},
+            secure=True,
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertRegex(resp.context["period"], r"^\d{4}-(0[1-9]|1[0-2])$")

--- a/core/views.py
+++ b/core/views.py
@@ -255,7 +255,7 @@ def dashboard(request):
         default_period = f"{current_date.year}-{current_date.month - 1:02d}"
     period = request.GET.get("period", default_period)
     if not re.match(r"^\d{4}-(0[1-9]|1[0-2])$", period or ""):
-        period = current_period
+        period = default_period
 
     prev_period = _shift_period(period, -1)
     next_period = _shift_period(period, 1)


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when the `period` query parameter is malformed and ensure period navigation handles year boundaries correctly.

### Description
- Use `default_period` as the fallback when `period` is invalid in `dashboard` (`core/views.py`).
- Add regression tests in `core/tests/test_dashboard_period.py` to verify year boundary navigation (`2025-12` → `2026-01`) and that an invalid `period` falls back to a valid value.

### Testing
- Ran `python -m pytest core/tests/test_dashboard_period.py -q` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88ad5b3e0832ca83b78a86eabc636)