### PR TITLE
Estimation: include full-year summaries and use prior-December baseline for January

### DIFF
--- a/core/services/finance_estimation.py
+++ b/core/services/finance_estimation.py
@@ -219,10 +219,26 @@ class FinanceEstimationService:
     def get_estimation_summary(self, period):
         """Get estimation summary for a specific period."""
         try:
-            # Get account balances for current and next period
-            current_balances = self.get_period_balances(period)
-            next_period = self.get_next_period(period)
-            next_balances = self.get_period_balances(next_period) if next_period else {}
+            # Get account balances for comparison periods.
+            # Business rule: January reconciles against December from the
+            # previous year; all other months reconcile against the next month.
+            balance_start_period = period
+            balance_end_period = self.get_next_period(period)
+
+            if period.month == 1:
+                previous_december = DatePeriod.objects.filter(
+                    year=period.year - 1, month=12
+                ).first()
+                if previous_december:
+                    balance_start_period = previous_december
+                    balance_end_period = period
+
+            current_balances = self.get_period_balances(balance_start_period)
+            next_balances = (
+                self.get_period_balances(balance_end_period)
+                if balance_end_period
+                else {}
+            )
 
             # Get recorded transactions for the period - separated by estimated vs real
             real_transactions = Transaction.objects.filter(

--- a/core/tests/test_estimate_transactions.py
+++ b/core/tests/test_estimate_transactions.py
@@ -264,3 +264,44 @@ def test_reestimate_does_not_affect_other_periods(
     assert qs_aug.first().id == aug_tx2.id
     assert qs_sep.count() == 1
     assert qs_sep.first().id == sep_tx.id
+
+
+@pytest.mark.django_db
+def test_january_summary_uses_previous_december_balance_for_estimation(
+    user, savings_account
+):
+    period_dec_prev = make_period("2024-12")
+    period_jan = make_period("2025-01")
+
+    set_balance(savings_account, period_dec_prev, Decimal("1000"))
+    set_balance(savings_account, period_jan, Decimal("800"))
+
+    service = FinanceEstimationService(user)
+    summary = service.get_estimation_summary(period_jan)
+
+    assert summary["status"] == "missing_expenses"
+    assert Decimal(str(summary["estimated_amount"])) == Decimal("200")
+
+
+@pytest.mark.django_db
+def test_estimation_summaries_year_filter_returns_january_to_december(
+    client, user, savings_account
+):
+    for month in range(1, 13):
+        period = make_period(f"2025-{month:02d}")
+        set_balance(savings_account, period, Decimal("1000"))
+
+    # Include another year to ensure year filter is respected.
+    period_2026 = make_period("2026-01")
+    set_balance(savings_account, period_2026, Decimal("1000"))
+
+    resp = client.get(reverse("get_estimation_summaries"), {"year": "2025"})
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["success"] is True
+    assert len(payload["summaries"]) == 12
+
+    labels = [summary["period"] for summary in payload["summaries"]]
+    assert "2025-01" in labels
+    assert "2025-12" in labels

--- a/core/views.py
+++ b/core/views.py
@@ -4064,8 +4064,13 @@ def get_estimation_summaries(request):
             except (ValueError, TypeError):
                 logger.warning(f"Invalid year filter: {year_filter}")
 
-        # Exclude the most recent period because we need next period data for estimation
-        periods = periods_qs[1:13]  # Skip first, get next 12 months
+        # For explicit year filters, return the full year (up to 12 months).
+        # Without filters, keep historical behavior of skipping the most recent
+        # period because the default estimation flow relies on forward balances.
+        if year_filter:
+            periods = periods_qs[:12]
+        else:
+            periods = periods_qs[1:13]  # Skip first, get next 12 months
 
         logger.debug(f"Found {periods.count()} periods for user {request.user.id}")
 


### PR DESCRIPTION
### Motivation
- Users expect the estimation management page to show January–December when filtering by year, and January estimates must use December of the previous year as the balance baseline to compute missing transactions correctly.

### Description
- Change `get_estimation_summaries` in `core/views.py` to return the full year (up to 12 months) when a `?year=` filter is provided, while preserving the historical behavior of skipping the most recent period when no year filter is present.
- Update `FinanceEstimationService.get_estimation_summary` in `core/services/finance_estimation.py` to use the previous year's December as the `balance_start_period` for January, falling back to the normal next-month logic for other months.
- Add regression tests in `core/tests/test_estimate_transactions.py` that assert January uses the previous December balance for estimation and that the year-filtered summaries include both January and December.

### Testing
- Ran `pytest -q core/tests/test_estimate_transactions.py` and observed `6 passed, 2 skipped` indicating the new behavior is covered and existing scenarios still pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88cc7aa78832ca44cb8a2b6e8a488)