### PR TITLE
Add month selection for bulk duplicate in transactions v2

### DIFF
--- a/core/static/js/transaction_list_v2.js
+++ b/core/static/js/transaction_list_v2.js
@@ -1485,8 +1485,26 @@ class TransactionManager {
       return;
     }
 
+    const monthsInput = prompt(
+      "Para que meses quer duplicar? (ex: 1,2,3)",
+      "1",
+    );
+    if (monthsInput === null) return;
+
+    const months = monthsInput
+      .split(",")
+      .map((value) => Number.parseInt(value.trim(), 10))
+      .filter((value) => Number.isInteger(value) && value > 0 && value <= 12);
+
+    if (months.length === 0) {
+      this.showError("❌ Please provide valid months between 1 and 12 (ex: 1,2,3)");
+      return;
+    }
+
+    const uniqueMonths = [...new Set(months)].sort((a, b) => a - b);
+
     const confirmed = confirm(
-      `Duplicate ${this.selectedRows.size} transactions?`,
+      `Duplicate ${this.selectedRows.size} transactions for month offset(s): ${uniqueMonths.join(", ")}?`,
     );
     if (!confirmed) return;
 
@@ -1509,6 +1527,7 @@ class TransactionManager {
         },
         body: JSON.stringify({
           transaction_ids: Array.from(this.selectedRows),
+          months: uniqueMonths,
         }),
       });
 

--- a/core/tests/test_transaction_bulk_duplicate.py
+++ b/core/tests/test_transaction_bulk_duplicate.py
@@ -1,0 +1,88 @@
+import json
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from core.models import DatePeriod, Tag, Transaction
+
+
+class TransactionBulkDuplicateViewTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user("tester", "tester@example.com", "pass")
+        self.client.force_login(self.user)
+        self.url = reverse("transaction_bulk_duplicate")
+
+    def test_bulk_duplicate_creates_requested_month_offsets_and_copies_tags(self):
+        original_tx = Transaction.objects.create(
+            user=self.user,
+            type=Transaction.Type.EXPENSE,
+            amount=Decimal("25.50"),
+            date=date(2024, 1, 31),
+            notes="Original",
+        )
+        food = Tag.objects.create(user=self.user, name="food")
+        monthly = Tag.objects.create(user=self.user, name="monthly")
+        original_tx.tags.add(food, monthly)
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(
+                {
+                    "transaction_ids": [original_tx.id],
+                    "months": [1, 2],
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["success"])
+        self.assertEqual(data["created"], 2)
+        self.assertEqual(data["months"], [1, 2])
+
+        duplicated_dates = sorted(
+            Transaction.objects.exclude(id=original_tx.id).values_list("date", flat=True)
+        )
+        self.assertEqual(duplicated_dates, [date(2024, 2, 29), date(2024, 3, 31)])
+
+        feb_period = DatePeriod.objects.get(year=2024, month=2)
+        mar_period = DatePeriod.objects.get(year=2024, month=3)
+        self.assertEqual(feb_period.label, "February 2024")
+        self.assertEqual(mar_period.label, "March 2024")
+
+        duplicated_tags = [
+            set(tx.tags.values_list("name", flat=True))
+            for tx in Transaction.objects.exclude(id=original_tx.id)
+        ]
+        self.assertEqual(duplicated_tags, [{"food", "monthly"}, {"food", "monthly"}])
+
+    def test_bulk_duplicate_rejects_invalid_months(self):
+        original_tx = Transaction.objects.create(
+            user=self.user,
+            type=Transaction.Type.EXPENSE,
+            amount=Decimal("10.00"),
+            date=date(2024, 1, 10),
+            notes="Original",
+        )
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(
+                {
+                    "transaction_ids": [original_tx.id],
+                    "months": [0, 14],
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertFalse(data["success"])
+        self.assertIn("month offsets", data["error"])
+        self.assertEqual(Transaction.objects.count(), 1)

--- a/core/views.py
+++ b/core/views.py
@@ -1205,13 +1205,32 @@ def transaction_bulk_update(request):
 @require_POST
 @login_required
 def transaction_bulk_duplicate(request):
-    """Bulk duplicate transactions."""
+    """Bulk duplicate transactions for selected month offsets."""
     try:
         data = json.loads(request.body)
         transaction_ids = data.get("transaction_ids", [])
+        months = data.get("months", [1])
 
         if not transaction_ids:
             return JsonResponse({"success": False, "error": "No transactions selected"})
+
+        if not isinstance(months, list):
+            return JsonResponse({"success": False, "error": "Invalid months format"})
+
+        valid_months = sorted(
+            {
+                int(month)
+                for month in months
+                if isinstance(month, int) and 1 <= int(month) <= 12
+            }
+        )
+        if not valid_months:
+            return JsonResponse(
+                {
+                    "success": False,
+                    "error": "Please provide month offsets between 1 and 12",
+                }
+            )
 
         # Get original transactions
         transactions = (
@@ -1226,47 +1245,56 @@ def transaction_bulk_duplicate(request):
             )
 
         created = 0
-        today = date.today()
-        current_period, _ = DatePeriod.objects.get_or_create(
-            year=today.year,
-            month=today.month,
-            defaults={"label": today.strftime("%B %Y")},
-        )
 
         # Use atomic transaction for all operations
         with db_transaction.atomic():
             new_transactions = []
             for tx in transactions:
-                # Create duplicate with today's date
-                new_tx = Transaction.objects.create(
-                    user=tx.user,
-                    type=tx.type,
-                    amount=tx.amount,
-                    date=today,
-                    notes=f"Duplicate of transaction from {tx.date}",
-                    is_estimated=tx.is_estimated,
-                    period=current_period,
-                    account=tx.account,
-                    category=tx.category,
-                )
-                new_transactions.append((new_tx, tx.tags.all()))
-                created += 1
+                original_tags = list(tx.tags.all())
+
+                for month_offset in valid_months:
+                    target_month_index = tx.date.month - 1 + month_offset
+                    target_year = tx.date.year + (target_month_index // 12)
+                    target_month = (target_month_index % 12) + 1
+                    target_day = min(tx.date.day, monthrange(target_year, target_month)[1])
+                    target_date = date(target_year, target_month, target_day)
+
+                    target_period, _ = DatePeriod.objects.get_or_create(
+                        year=target_year,
+                        month=target_month,
+                        defaults={"label": target_date.strftime("%B %Y")},
+                    )
+
+                    new_tx = Transaction.objects.create(
+                        user=tx.user,
+                        type=tx.type,
+                        amount=tx.amount,
+                        date=target_date,
+                        notes=f"Duplicate of transaction from {tx.date}",
+                        is_estimated=tx.is_estimated,
+                        period=target_period,
+                        account=tx.account,
+                        category=tx.category,
+                    )
+                    new_transactions.append((new_tx, original_tags))
+                    created += 1
 
             # Copy tags for all new transactions
             for new_tx, original_tags in new_transactions:
-                for tag in original_tags:
-                    new_tx.tags.add(tag)
+                if original_tags:
+                    new_tx.tags.add(*original_tags)
 
         # Clear cache only AFTER all database operations are complete
         clear_tx_cache(request.user.id, force=True)
         logger.info(
-            f"✅ Bulk duplicate completed: {created} transactions created, cache cleared for user {request.user.id}"
+            f"✅ Bulk duplicate completed: {created} transactions created for offsets {valid_months}, cache cleared for user {request.user.id}"
         )
 
         return JsonResponse(
             {
                 "success": True,
                 "created": created,
+                "months": valid_months,
                 "message": f"{created} transactions duplicated",
             }
         )


### PR DESCRIPTION
### Motivation
- Provide the Bulk Select Mode duplicate action with the ability to duplicate selected transactions into additional month offsets as requested by product. 
- Ensure duplication preserves tags and produces valid end-of-month dates (e.g. 31 → 29/30 where applicable).

### Description
- Updated the transactions v2 frontend (`core/static/js/transaction_list_v2.js`) to prompt the user for month offsets (CSV like `1,2,3`), validate input, deduplicate/sort offsets, and send `months` with the duplicate request. 
- Enhanced the backend view (`transaction_bulk_duplicate` in `core/views.py`) to accept and validate a `months` array (integers 1–12), compute target dates using calendar-aware arithmetic, create or re-use `DatePeriod` objects, create duplicated `Transaction` rows for each requested offset, and copy tags efficiently with `add(*tags)`. 
- Added server-side validation that rejects invalid payloads (missing transaction IDs or invalid months) and returns informative JSON errors. 
- Added automated tests (`core/tests/test_transaction_bulk_duplicate.py`) that verify successful duplication (including end-of-month handling and tag copying) and rejection of invalid month inputs.

### Testing
- Ran `pytest -q core/tests/test_transaction_bulk_duplicate.py` which executed the two new tests. 
- Result: `2 passed` (both tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8a11e4290832cacf3e21071596dcd)